### PR TITLE
init(프론트 초기설정): status check rule에 시작문자 한글 허용

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -53,8 +53,8 @@ jobs:
             remove
             revert
           requireScope: false
-          subjectPattern: ^[a-z].+$
+          subjectPattern: ^[a-z가-힣].+$
           subjectPatternError: |
-            The subject must start with a lowercase letter and not end with a period.
+            The subject must start with a lowercase letter or a Korean character and not end with a period.
           wip: false
           validateSingleCommit: false


### PR DESCRIPTION
## 개요
pr status check 에서 기존의 규칙(영어 소문자로시작) 에 한글 글자 허용을 하였습니다.

## 변경사항
한글이 pr 제목에 들어갈 경우 fail 되던 이슈 해결

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).