### PR TITLE
fix: 사파리에서 바텀시트가 일부만 보이는 문제 해결

### DIFF
--- a/src/components/bottom-sheet/BottomSheet.tsx
+++ b/src/components/bottom-sheet/BottomSheet.tsx
@@ -14,7 +14,7 @@ const BottomSheet = forwardRef<HTMLDivElement, Props>(
           <div
             ref={ref}
             role="dialog"
-            className="fixed -bottom-60 left-0 right-0 mx-auto hidden h-fit max-h-[90dvh] min-h-100 w-full max-w-500 -translate-x-1/2 flex-col rounded-t-[20px] bg-white px-32 pb-60 transition-transform duration-0 ease-out"
+            className="fixed -bottom-60 left-0 right-0 mx-auto hidden max-h-[90dvh] min-h-100 w-full max-w-500 -translate-x-1/2 flex-col rounded-t-[20px] bg-white px-32 pb-60 transition-transform duration-0 ease-out"
           >
             <div className="mx-auto my-8 h-4 w-[70px] shrink-0 rounded-full bg-grey-100" />
             {title && (


### PR DESCRIPTION
## 개요

사파리에서 바텀시트가 제대로 보이지 않는 문제를 해결했습니다.

## 변경사항
### 수정 전
<img width="567" alt="스크린샷 2024-11-15 오전 11 23 53" src="https://github.com/user-attachments/assets/753420eb-e136-457c-8bff-bb4f1db31d70">

### 수정 후
<img width="561" alt="스크린샷 2024-11-15 오전 11 24 02" src="https://github.com/user-attachments/assets/a86ec869-ada1-494f-92ee-507c65475032">



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).