### PR TITLE
fix(로그인): 로그아웃 이후에도 마이페이지 캐싱을 통해 접근 가능했던 문제 해결

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,5 +9,5 @@ export const middleware = async (req: NextRequest) => {
 };
 
 export const config = {
-  matcher: '/mypage',
+  matcher: ['/mypage'],
 };

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -26,7 +26,7 @@ export const postLogin = async (
           }
         : undefined,
   };
-  const res = await instance.post('/auth', body);
+  const res = await instance.post('/auth/login', body);
   const data: TokenType = res.data;
   return data;
 };

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from 'axios';
 import { postRefreshToken } from './auth';
 import { setAccessToken, setRefreshToken } from '@/utils/handleToken';
-import { removeSession } from '@/utils/handleSession';
+import { handleLogout } from '@/utils/handleSession';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
@@ -31,7 +31,7 @@ authInstance.interceptors.response.use(
       } catch (e) {
         const error = e as AxiosError;
         if (error.status === 401) {
-          removeSession();
+          handleLogout();
           window.location.href = '/login';
         }
         console.error(error);

--- a/src/utils/handleSession.ts
+++ b/src/utils/handleSession.ts
@@ -1,5 +1,6 @@
 import { Cookies } from 'react-cookie';
 import { removeRefreshToken } from './handleToken';
+import { revalidatePath } from 'next/cache';
 
 const SESSION = 'session';
 
@@ -15,10 +16,11 @@ export const setSession = () => {
 };
 
 export const removeSession = () => {
-  cookieStore.remove(SESSION);
+  cookieStore.remove(SESSION, { path: '/' });
 };
 
 export const handleLogout = () => {
   removeSession();
   removeRefreshToken();
+  revalidatePath('/mypage');
 };


### PR DESCRIPTION
## 개요

로그아웃 이후에도 next에서 캐싱한 마이페이지를 통해 접근 가능했던 문제를 해결했습니다.

## 변경사항
handleLogout 함수에 `/mypage`를 revalidate하는 함수를 추가하여 캐시를 초기화해주었습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).