### PR TITLE
fix: pm2 중복 실행 제거

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -9,8 +9,8 @@ permissions:
     owner: ubuntu
     group: ubuntu
     mode: 755
-hooks:
-  AfterInstall:
-    - location: deploy.sh
-      timeout: 60
-      runas: ubuntu
+# hooks:
+#   AfterInstall:
+#     - location: deploy.sh
+#       timeout: 60
+#       runas: ubuntu

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,2 +1,3 @@
+pm2 kill
 cd /usr/share/nginx/html
 pm2 start ecosystem.config.js --name handybus-web


### PR DESCRIPTION
## 개요

ec2 instance에서 pm2를 중복 실행하던 로직을 제거했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).