### PR TITLE
feat: shuttle visualizer blur effect 업데이트

### DIFF
--- a/src/components/shuttle/shuttle-route-visualizer/ShuttleRouteVisualizer.stories.tsx
+++ b/src/components/shuttle/shuttle-route-visualizer/ShuttleRouteVisualizer.stories.tsx
@@ -1,0 +1,55 @@
+import { Meta, StoryObj } from '@storybook/react';
+import ShuttleRouteVisualizer from './ShuttleRouteVisualizer';
+import { SECTION } from '@/types/shuttle.types';
+
+const meta: Meta<typeof ShuttleRouteVisualizer> = {
+  title: 'Components/ShuttleRouteVisualizer',
+  component: ShuttleRouteVisualizer,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ShuttleRouteVisualizer>;
+
+export const ShuttleDetail: Story = {
+  args: {
+    object: [
+      { time: '2024-03-20 14:30:00', location: '청주터미널' },
+      { time: '2024-03-20 14:40:00', location: '청주대학교' },
+      { time: '2024-03-20 14:50:00', location: '장소3' },
+      { time: '2024-03-20 15:00:00', location: '장소4' },
+      { time: '2024-03-20 15:10:00', location: '장소5' },
+      { time: '2024-03-20 15:20:00', location: '장소6' },
+    ],
+    section: SECTION.SHUTTLE_DETAIL,
+  },
+};
+
+export const ReservationDetail: Story = {
+  args: {
+    object: [
+      { time: '2024-03-20 14:30:00', location: '청주터미널' },
+      { time: '2024-03-20 14:40:00', location: '청주대학교', is_pickup: true },
+      { time: '2024-03-20 14:50:00', location: '장소3' },
+      { time: '2024-03-20 15:00:00', location: '장소4' },
+      { time: '2024-03-20 15:10:00', location: '장소5' },
+      { time: '2024-03-20 15:20:00', location: '장소6', is_dropoff: true },
+    ],
+    section: SECTION.RESERVATION_DETAIL,
+  },
+};
+
+export const MyReservation: Story = {
+  args: {
+    object: [
+      { time: '2024-03-20 14:30:00', location: '청주터미널' },
+      { time: '2024-03-20 14:40:00', location: '청주대학교', is_pickup: true },
+      { time: '2024-03-20 14:50:00', location: '장소3', is_dropoff: true },
+      { time: '2024-03-20 15:00:00', location: '장소4' },
+      { time: '2024-03-20 15:10:00', location: '장소5' },
+      { time: '2024-03-20 15:20:00', location: '장소6' },
+    ],
+    section: SECTION.MY_RESERVATION,
+  },
+};

--- a/src/components/shuttle/shuttle-route-visualizer/ShuttleRouteVisualizer.tsx
+++ b/src/components/shuttle/shuttle-route-visualizer/ShuttleRouteVisualizer.tsx
@@ -101,7 +101,18 @@ const ShuttleRouteCard = ({ section, type, object }: ShuttleRouteCardProps) => {
         <ul className="flex flex-col gap-16">
           {object.map((item, index) => (
             <li key={index}>
-              <ShuttleRouteTimeLocation object={item} />
+              <ShuttleRouteTimeLocation
+                object={item}
+                isBlurred={
+                  section !== SECTION.SHUTTLE_DETAIL &&
+                  isShuttleRouteLocationBlurred({
+                    object: item,
+                    type,
+                    index,
+                    length: object.length,
+                  })
+                }
+              />
             </li>
           ))}
         </ul>
@@ -148,17 +159,38 @@ const ArrivalPoint = ({ type }: { type: RouteType }) => {
 
 const ShuttleRouteTimeLocation = ({
   object,
+  isBlurred,
 }: {
   object: ShuttleRouteObject;
+  isBlurred: boolean;
 }) => {
   return (
     <div className="flex gap-16">
       <p className="text-16 font-400 leading-[24px] text-grey-900">
         {dayjs(object.time).format('HH:mm')}
       </p>
-      <p className="text-16 font-400 leading-[24px] text-grey-900">
+      <p
+        className={`text-16 font-400 leading-[24px] ${isBlurred ? 'text-grey-300' : 'text-grey-900'}`}
+      >
         {object.location}
       </p>
     </div>
   );
+};
+
+const isShuttleRouteLocationBlurred = ({
+  object,
+  type,
+  index,
+  length,
+}: {
+  object: ShuttleRouteObject;
+  type: RouteType;
+  index: number;
+  length: number;
+}) => {
+  if (type === ROUTE_TYPE.DEPARTURE)
+    return !(index === length - 1 || object.is_pickup);
+  if (type === ROUTE_TYPE.RETURN) return !(index === 0 || object.is_dropoff);
+  return false;
 };

--- a/src/types/shuttle.types.ts
+++ b/src/types/shuttle.types.ts
@@ -8,12 +8,14 @@ export type RouteType = (typeof ROUTE_TYPE)[keyof typeof ROUTE_TYPE];
 export type ShuttleRouteObject = {
   time: string;
   location: string;
+  is_pickup?: boolean;
+  is_dropoff?: boolean;
 };
 
 export const SECTION = {
-  SHUTTLE_DETAIL: 'shuttle-detail',
-  RESERVATION_DETAIL: 'reservation-detail',
-  MY_RESERVATION: 'my-reservation',
+  SHUTTLE_DETAIL: 'SHUTTLE-DETAIL',
+  RESERVATION_DETAIL: 'RESERVATION-DETAIL',
+  MY_RESERVATION: 'MY-RESERVATION',
 } as const;
 
 export type SectionType = (typeof SECTION)[keyof typeof SECTION];


### PR DESCRIPTION
## 개요

예약  페이지 및 마이페이지(셔틀) 에서 사용될 노선 비주얼라이저 블러 이펙트 업데이트 입니다

Props는 아래와 같이 사용할 수 있어요. section을 `RESERVATION_DETAIL`(예약하기) 과 `MY_RESERVATION` (마이페이지-셔틀)두면 주요 `승탑지, 출발지, 도착지`를 제외하고는 블러처리됩니다.
출발지 방향 일땐 `is_pickup` 을, 도착지 방향일땐 `is_dropoff` 를 true 로 두고 사용하세요
```
    object: [
      { time: '2024-03-20 14:30:00', location: '청주터미널' },
      { time: '2024-03-20 14:40:00', location: '청주대학교', is_pickup: true },
      { time: '2024-03-20 14:50:00', location: '장소3' },
      { time: '2024-03-20 15:00:00', location: '장소4' },
      { time: '2024-03-20 15:10:00', location: '장소5' },
      { time: '2024-03-20 15:20:00', location: '장소6', is_dropoff: true },
    ],
    section: SECTION.RESERVATION_DETAIL,
```

<img width="522" alt="Screenshot 2024-12-03 at 12 17 43 AM" src="https://github.com/user-attachments/assets/abb7a8db-e056-4382-a905-7130db061d73">

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).