### PR TITLE
feat(마이페이지): 마이페이지 - 셔틀 구현

### DIFF
--- a/src/app/mypage/reviews/write/[id]/page.tsx
+++ b/src/app/mypage/reviews/write/[id]/page.tsx
@@ -9,8 +9,6 @@ import { toast } from 'react-toastify';
 import Image from 'next/image';
 import { MAX_FILE_SIZE } from '@/constants/common';
 import XIcon from 'public/icons/x.svg';
-import { MOCK_SHUTTLE_DATA } from '@/app/mypage/shuttle/components/ShuttleCard';
-import ShuttleCard from '@/app/mypage/shuttle/components/ShuttleCard';
 
 const WriteReview = () => {
   const [rating, setRating] = useState(0);
@@ -52,7 +50,7 @@ const WriteReview = () => {
     <>
       <AppBar>후기 작성</AppBar>
       <form onSubmit={handleSubmit} className="relative grow">
-        <ShuttleCard id={1} data={MOCK_SHUTTLE_DATA} />
+        {/* <ShuttleCard id={1} data={MOCK_SHUTTLE_DATA} /> */}
         <section className="flex w-full flex-col gap-16 p-28">
           <h5>이번 셔틀의 만족도를 입력해주세요</h5>
           <div>

--- a/src/app/mypage/shuttle/[id]/page.tsx
+++ b/src/app/mypage/shuttle/[id]/page.tsx
@@ -1,4 +1,3 @@
-import ShuttleCard, { MOCK_SHUTTLE_DATA } from '../components/ShuttleCard';
 import { ReactNode } from 'react';
 import Section from '../components/Section';
 import Button from '@/components/buttons/button/Button';
@@ -23,7 +22,7 @@ const ShuttleDetail = ({ params }: Props) => {
     <>
       <AppBar>예약 상세 보기</AppBar>
       <main className="grow">
-        <ShuttleCard id={1} data={MOCK_SHUTTLE_DATA} />
+        {/* <ShuttleCard id={1} data={MOCK_SHUTTLE_DATA} /> */}
         <Section title="당신은 핸디입니다~">TODO</Section>
         <Section title="예약 정보">
           <div className="flex flex-col gap-28">

--- a/src/app/mypage/shuttle/[id]/refund/page.tsx
+++ b/src/app/mypage/shuttle/[id]/refund/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import AppBar from '@/components/app-bar/AppBar';
-import ShuttleCard, { MOCK_SHUTTLE_DATA } from '../../components/ShuttleCard';
 import Section from '../../components/Section';
 import RefundPolicy from '../../components/RefundPolicy';
 import { CancellationAndRefundContent } from '@/components/notice-section/NoticeSection';
@@ -19,7 +18,7 @@ const Refund = () => {
     <>
       <AppBar>환불 신청</AppBar>
       <main className="grow">
-        <ShuttleCard id={1} data={MOCK_SHUTTLE_DATA} />
+        {/* <ShuttleCard id={1} data={MOCK_SHUTTLE_DATA} /> */}
         <Section title="유의사항">
           <RefundPolicy />
         </Section>

--- a/src/app/mypage/shuttle/components/DemandCard.tsx
+++ b/src/app/mypage/shuttle/components/DemandCard.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { ID_TO_REGION } from '@/constants/regions';
+import { ShuttleDemandType } from '@/types/client.types';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { MouseEvent } from 'react';
+import {
+  DEMAND_STATUS_TEXT,
+  STATUS_STYLE,
+  StatusType,
+  TRIP_TEXT,
+} from '../constants/shuttle.constants';
+
+interface Props {
+  demand: ShuttleDemandType;
+  buttonText?: string;
+  buttonHref?: string;
+  buttonDisabled?: boolean;
+  subButtonText?: string;
+  subButtonHref?: string;
+  subButtonDisabled?: boolean;
+  subButtonOnClick?: () => void;
+}
+
+const DemandCard = ({
+  demand,
+  buttonText,
+  buttonHref,
+  buttonDisabled,
+  subButtonText,
+  subButtonHref,
+  subButtonDisabled,
+  subButtonOnClick,
+}: Props) => {
+  const router = useRouter();
+  const handleButtonClick =
+    (href: string) => (e: MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      router.push(href);
+    };
+
+  const getStatusStyle = (status: StatusType) => {
+    switch (status) {
+      case '수요 확인 중':
+      case '예약 모집 중':
+      case '배차 확정':
+        return STATUS_STYLE.fullGreen;
+      case '수요 신청 마감':
+      case '예약 모집 마감':
+        return STATUS_STYLE.emptyGreen;
+      case '운행 종료':
+      case '무산':
+        return STATUS_STYLE.darkGrey;
+      case '무산':
+      case '비활성':
+        return STATUS_STYLE.lightGrey;
+    }
+  };
+
+  const region = ID_TO_REGION[demand.regionID];
+  const routeText = `${region.bigRegion} ${region.smallRegion} (${TRIP_TEXT[demand.type]})`;
+  const status = DEMAND_STATUS_TEXT[demand.status];
+  const statusStyle = getStatusStyle(status);
+
+  return (
+    <Link
+      href={`/shuttle-detail/${demand.shuttle.id}`}
+      className="flex w-full flex-col gap-12 p-16"
+    >
+      <div className="flex items-center gap-8 text-12">
+        <div className={`h-[10px] w-[10px] rounded-full ${statusStyle.dot}`} />
+        <span className={`font-600 ${statusStyle.text}`}>{status}</span>
+        <span className="font-500 text-grey-500">{demand.createdAt} 신청</span>
+      </div>
+      <div className="flex h-[110px] w-full gap-16">
+        <div className="relative h-full w-80 overflow-hidden rounded-[8px]">
+          <Image
+            src={demand.shuttle.image}
+            alt="행사 포스터"
+            fill
+            className="object-cover"
+          />
+        </div>
+        <div className="flex flex-col">
+          <span className="pb-4 text-16 font-500 text-grey-900">
+            {demand.shuttle.name}
+          </span>
+          <span className="text-12 font-400 text-grey-900">
+            {demand.shuttle.destination.name}
+          </span>
+          <span className="text-12 font-400 text-grey-900">
+            {demand.shuttle.date} 셔틀
+          </span>
+          <span className="flex gap-12 text-12 font-400 text-grey-500">
+            <span>{routeText}</span>
+            <span>{demand.passengerCount}인</span>
+          </span>
+        </div>
+      </div>
+      <div className="flex gap-8">
+        {buttonText && buttonHref && (
+          <button
+            onClick={handleButtonClick(buttonHref)}
+            disabled={buttonDisabled}
+            type="button"
+            className="flex h-40 w-full items-center justify-center rounded-full bg-primary-main text-14 font-500 text-white active:bg-primary-700 disabled:bg-grey-50 disabled:text-grey-300"
+          >
+            {buttonText}
+          </button>
+        )}
+        {subButtonText && (
+          <button
+            onClick={
+              subButtonOnClick ||
+              (subButtonHref ? handleButtonClick(subButtonHref) : undefined)
+            }
+            disabled={subButtonDisabled}
+            type="button"
+            className="flex h-40 w-full items-center justify-center rounded-full bg-grey-50 text-14 font-500 text-grey-700 disabled:bg-grey-50 disabled:text-grey-300"
+          >
+            {subButtonText}
+          </button>
+        )}
+      </div>
+    </Link>
+  );
+};
+
+export default DemandCard;

--- a/src/app/mypage/shuttle/components/ReservationCard.tsx
+++ b/src/app/mypage/shuttle/components/ReservationCard.tsx
@@ -1,25 +1,18 @@
 'use client';
 
+import { ReservationType } from '@/types/client.types';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { MouseEvent } from 'react';
+import {
+  RESERVATION_STATUS_TEXT,
+  TRIP_TEXT,
+} from '../constants/shuttle.constants';
+import { STATUS_STYLE, StatusType } from '../constants/shuttle.constants';
 
 interface Props {
-  id: number;
-  data: {
-    imageSrc: string;
-    type: '신청' | '예약';
-    title: string;
-    location: string;
-    date: string;
-    route: string;
-    shuttleType: '왕복' | '귀가행' | '콘서트행';
-    passengerCount: number;
-    status: '수요 확인 중' | '신청 마감' | '예약 모집 중' | '무산';
-    price?: number;
-    reservationDate?: string;
-  };
+  reservation: ReservationType;
   buttonText?: string;
   buttonHref?: string;
   buttonDisabled?: boolean;
@@ -28,9 +21,8 @@ interface Props {
   subButtonDisabled?: boolean;
 }
 
-const ShuttleCard = ({
-  id,
-  data,
+const ReservationCard = ({
+  reservation,
   buttonText,
   buttonHref,
   buttonDisabled,
@@ -45,26 +37,43 @@ const ShuttleCard = ({
       router.push(href);
     };
 
+  const getStatusStyle = (status: StatusType) => {
+    switch (status) {
+      case '수요 확인 중':
+      case '예약 모집 중':
+      case '배차 확정':
+        return STATUS_STYLE.fullGreen;
+      case '수요 신청 마감':
+      case '예약 모집 마감':
+        return STATUS_STYLE.emptyGreen;
+      case '운행 종료':
+      case '무산':
+        return STATUS_STYLE.darkGrey;
+      case '무산':
+      case '비활성':
+        return STATUS_STYLE.lightGrey;
+    }
+  };
+
+  const status = RESERVATION_STATUS_TEXT[reservation.shuttle.route.status];
+  const statusStyle = getStatusStyle(status);
+
   return (
     <Link
-      href={`/shuttle-detail/${id}`}
+      href={`/shuttle-detail/${reservation.id}`}
       className="flex w-full flex-col gap-12 p-16"
     >
       <div className="flex items-center gap-8 text-12">
-        <div
-          className={`h-[10px] w-[10px] rounded-full ${STATUS_STYLE[data.status].dot}`}
-        />
-        <span className={`font-600 ${STATUS_STYLE[data.status].text}`}>
-          {data.status}
-        </span>
+        <div className={`h-[10px] w-[10px] rounded-full ${statusStyle.dot}`} />
+        <span className={`font-600 ${statusStyle.text}`}>{status}</span>
         <span className="font-500 text-grey-500">
-          {data.reservationDate} {data.type}
+          {reservation.createdAt} 예약
         </span>
       </div>
       <div className="flex h-[110px] w-full gap-16">
         <div className="relative h-full w-80 overflow-hidden rounded-[8px]">
           <Image
-            src={data.imageSrc}
+            src={reservation.shuttle.image}
             alt="행사 포스터"
             fill
             className="object-cover"
@@ -72,25 +81,25 @@ const ShuttleCard = ({
         </div>
         <div className="flex flex-col">
           <span className="pb-4 text-16 font-500 text-grey-900">
-            {data.title}
+            {reservation.shuttle.name}
           </span>
           <span className="text-12 font-400 text-grey-900">
-            {data.location}
+            {reservation.shuttle.destination.name}
           </span>
           <span className="text-12 font-400 text-grey-900">
-            {data.date} 셔틀
+            {reservation.shuttle.date} 셔틀
           </span>
           <span className="flex gap-12 text-12 font-400 text-grey-500">
             <span>
-              {data.route} ({data.shuttleType})
+              {reservation.shuttle.route.name} ({TRIP_TEXT[reservation.type]})
             </span>
-            <span>{data.passengerCount}인</span>
+            {/* TODO: 승객 수 추가 */}
+            <span>{2}인</span>
           </span>
-          {data?.price && (
-            <span className="pt-4 text-14 font-500 text-grey-900">
-              {data.price.toLocaleString()} <span className="text-12">원</span>
-            </span>
-          )}
+          <span className="pt-4 text-14 font-500 text-grey-900">
+            {reservation.payment.paymentAmount.toLocaleString()}{' '}
+            <span className="text-12">원</span>
+          </span>
         </div>
       </div>
       <div className="flex gap-8">
@@ -119,38 +128,4 @@ const ShuttleCard = ({
   );
 };
 
-export default ShuttleCard;
-
-const STATUS_STYLE = {
-  '예약 모집 중': {
-    dot: 'bg-primary-main',
-    text: 'text-primary-main',
-  },
-  '수요 확인 중': {
-    dot: 'border-2 border-primary-main',
-    text: 'text-primary-main',
-  },
-  '신청 마감': {
-    dot: 'bg-grey-700',
-    text: 'text-grey-700',
-  },
-  무산: {
-    dot: 'bg-grey-500',
-    text: 'text-grey-500',
-  },
-};
-
-export const MOCK_SHUTTLE_DATA = {
-  imageSrc:
-    'https://image.xportsnews.com/contents/images/upload/article/2024/0724/mb_1721807906980977.jpg',
-  title: '민트페스타 vol.74 STIRRING',
-  location: 'KT&G 상상마당 라이브홀',
-  date: '2024. 08. 25. (일)',
-  route: '충청북도 청주시',
-  shuttleType: '귀가행',
-  passengerCount: 2,
-  status: '수요 확인 중',
-  reservationDate: '2024. 07. 31. (수)',
-  type: '신청',
-  price: 10000,
-} as const;
+export default ReservationCard;

--- a/src/app/mypage/shuttle/components/ReservationCard.tsx
+++ b/src/app/mypage/shuttle/components/ReservationCard.tsx
@@ -100,6 +100,7 @@ const ReservationCard = ({
             {reservation.payment.paymentAmount.toLocaleString()}{' '}
             <span className="text-12">원</span>
           </span>
+          {/* TODO: 핸디 신청 상태 & 환불 신청 상태를 tag로 보여주기 */}
         </div>
       </div>
       <div className="flex gap-8">

--- a/src/app/mypage/shuttle/components/tabs/CurrentTab.tsx
+++ b/src/app/mypage/shuttle/components/tabs/CurrentTab.tsx
@@ -1,6 +1,5 @@
-import { MOCK_SHUTTLE_DATA } from '../ShuttleCard';
-
-import ShuttleCard from '../ShuttleCard';
+import { ReservationType } from '@/types/client.types';
+import ShuttleCard, { MOCK_SHUTTLE_DATA } from '../ShuttleCard';
 
 const CurrentTab = () => {
   return (
@@ -24,3 +23,64 @@ const CurrentTab = () => {
 };
 
 export default CurrentTab;
+
+export const MOCK_RESERVATION_DATA: ReservationType = {
+  id: 0,
+  shuttle: {
+    id: 0,
+    name: 'string',
+    date: 'string',
+    image: 'string',
+    status: 'OPEN',
+    destination: {
+      name: 'string',
+      longitude: 0,
+      latitude: 0,
+    },
+    route: {
+      name: 'string',
+      status: 'OPEN',
+      hubs: {
+        pickup: [
+          {
+            name: 'string',
+            sequence: 0,
+            arrivalTime: 'string',
+            selected: true,
+          },
+        ],
+        dropoff: [
+          {
+            name: 'string',
+            sequence: 0,
+            arrivalTime: 'string',
+            selected: true,
+          },
+        ],
+      },
+    },
+  },
+  hasReview: true,
+  review: {
+    id: 0,
+    rating: 0,
+    content: 'string',
+    images: [
+      {
+        imageUrl: 'https://example.com/image.jpg',
+        createdAt: 'string',
+        updatedAt: 'string',
+      },
+    ],
+    createdAt: 'string',
+  },
+  reservationStatus: 'NOT_PAYMENT',
+  cancelStatus: 'NONE',
+  handyStatus: 'NOT_SUPPORTED',
+  payment: {
+    id: 0,
+    principalAmount: 0,
+    paymentAmount: 0,
+    discountAmount: 0,
+  },
+};

--- a/src/app/mypage/shuttle/components/tabs/CurrentTab.tsx
+++ b/src/app/mypage/shuttle/components/tabs/CurrentTab.tsx
@@ -1,0 +1,26 @@
+import { MOCK_SHUTTLE_DATA } from '../ShuttleCard';
+
+import ShuttleCard from '../ShuttleCard';
+
+const CurrentTab = () => {
+  return (
+    <ul>
+      <ShuttleCard
+        id={1}
+        data={MOCK_SHUTTLE_DATA}
+        subButtonText="예약 상세보기"
+        subButtonHref="/mypage/shuttle/1"
+      />
+      <ShuttleCard
+        id={1}
+        data={MOCK_SHUTTLE_DATA}
+        buttonText="후기 작성하기"
+        buttonHref="/mypage/reviews/write"
+        subButtonText="예약 상세보기"
+        subButtonHref="/mypage/shuttle/1/"
+      />
+    </ul>
+  );
+};
+
+export default CurrentTab;

--- a/src/app/mypage/shuttle/components/tabs/CurrentTab.tsx
+++ b/src/app/mypage/shuttle/components/tabs/CurrentTab.tsx
@@ -1,86 +1,23 @@
 import { ReservationType } from '@/types/client.types';
-import ShuttleCard, { MOCK_SHUTTLE_DATA } from '../ShuttleCard';
+import ReservationCard from '../ReservationCard';
 
-const CurrentTab = () => {
+interface Props {
+  reservations: ReservationType[];
+}
+
+const CurrentTab = ({ reservations }: Props) => {
   return (
     <ul>
-      <ShuttleCard
-        id={1}
-        data={MOCK_SHUTTLE_DATA}
-        subButtonText="예약 상세보기"
-        subButtonHref="/mypage/shuttle/1"
-      />
-      <ShuttleCard
-        id={1}
-        data={MOCK_SHUTTLE_DATA}
-        buttonText="후기 작성하기"
-        buttonHref="/mypage/reviews/write"
-        subButtonText="예약 상세보기"
-        subButtonHref="/mypage/shuttle/1/"
-      />
+      {reservations.map((reservation) => (
+        <ReservationCard
+          key={reservation.id}
+          reservation={reservation}
+          subButtonText="예약 상세보기"
+          subButtonHref={`/mypage/shuttle/${reservation.id}`}
+        />
+      ))}
     </ul>
   );
 };
 
 export default CurrentTab;
-
-export const MOCK_RESERVATION_DATA: ReservationType = {
-  id: 0,
-  shuttle: {
-    id: 0,
-    name: 'string',
-    date: 'string',
-    image: 'string',
-    status: 'OPEN',
-    destination: {
-      name: 'string',
-      longitude: 0,
-      latitude: 0,
-    },
-    route: {
-      name: 'string',
-      status: 'OPEN',
-      hubs: {
-        pickup: [
-          {
-            name: 'string',
-            sequence: 0,
-            arrivalTime: 'string',
-            selected: true,
-          },
-        ],
-        dropoff: [
-          {
-            name: 'string',
-            sequence: 0,
-            arrivalTime: 'string',
-            selected: true,
-          },
-        ],
-      },
-    },
-  },
-  hasReview: true,
-  review: {
-    id: 0,
-    rating: 0,
-    content: 'string',
-    images: [
-      {
-        imageUrl: 'https://example.com/image.jpg',
-        createdAt: 'string',
-        updatedAt: 'string',
-      },
-    ],
-    createdAt: 'string',
-  },
-  reservationStatus: 'NOT_PAYMENT',
-  cancelStatus: 'NONE',
-  handyStatus: 'NOT_SUPPORTED',
-  payment: {
-    id: 0,
-    principalAmount: 0,
-    paymentAmount: 0,
-    discountAmount: 0,
-  },
-};

--- a/src/app/mypage/shuttle/components/tabs/DemandTab.tsx
+++ b/src/app/mypage/shuttle/components/tabs/DemandTab.tsx
@@ -1,23 +1,45 @@
+'use client';
+
 import { ReactNode } from 'react';
 import SmallBusIcon from 'public/icons/bus-small.svg';
 import { ShuttleDemandType } from '@/types/client.types';
 import DemandCard from '../DemandCard';
+import { ID_TO_REGION } from '@/constants/regions';
+import { getRoutes } from '@/services/shuttleOperation';
 
 interface Props {
   demands: ShuttleDemandType[];
 }
 
 const DemandTab = ({ demands }: Props) => {
+  const reservationOngoingDemands = demands.filter(async (demand) => {
+    if (demand.status !== 'SHUTTLE_ASSIGNED') {
+      return false;
+    }
+    const region = ID_TO_REGION[demand.regionID];
+    const routes = await getRoutes(
+      demand.shuttle.id,
+      demand.dailyShuttleID,
+      region,
+    );
+    if (routes.length === 0) {
+      return false;
+    }
+    return true;
+  });
+
   return (
     <ul>
       <ReservationOngoingWrapper>
         <div />
-        {/* <ShuttleCard
-          id={1}
-          data={MOCK_SHUTTLE_DATA}
-          buttonText="현재 예약이 진행되고 있는 셔틀이 있어요!"
-          buttonHref="/shuttle-detail"
-        /> */}
+        {reservationOngoingDemands.map((demand) => (
+          <DemandCard
+            key={demand.id}
+            demand={demand}
+            buttonText="현재 예약이 진행되고 있는 셔틀이 있어요!"
+            buttonHref={`/shuttle-detail/${demand.shuttle.id}`}
+          />
+        ))}
       </ReservationOngoingWrapper>
       {demands.map((demand) => (
         <DemandCard

--- a/src/app/mypage/shuttle/components/tabs/DemandTab.tsx
+++ b/src/app/mypage/shuttle/components/tabs/DemandTab.tsx
@@ -1,0 +1,58 @@
+import { ReactNode } from 'react';
+import ShuttleCard from '../ShuttleCard';
+import { MOCK_SHUTTLE_DATA } from '../ShuttleCard';
+import SmallBusIcon from 'public/icons/bus-small.svg';
+
+const DemandTab = () => {
+  return (
+    <ul>
+      <ReservationOngoingWrapper>
+        <ShuttleCard
+          id={1}
+          data={MOCK_SHUTTLE_DATA}
+          buttonText="현재 예약이 진행되고 있는 셔틀이 있어요!"
+          buttonHref="/shuttle-detail"
+        />
+      </ReservationOngoingWrapper>
+      <ShuttleCard
+        id={1}
+        data={MOCK_SHUTTLE_DATA}
+        subButtonText="예약 상세보기"
+        subButtonHref="/mypage/shuttle/1"
+      />
+      <ShuttleCard
+        id={1}
+        data={MOCK_SHUTTLE_DATA}
+        buttonText="후기 작성하기"
+        buttonHref="/mypage/reviews/write"
+        subButtonText="예약 상세보기"
+        subButtonHref="/mypage/shuttle/1/"
+      />
+    </ul>
+  );
+};
+
+export default DemandTab;
+
+interface ReservationOngoingWrapperProps {
+  children: ReactNode;
+}
+
+const ReservationOngoingWrapper = ({
+  children,
+}: ReservationOngoingWrapperProps) => {
+  return (
+    <>
+      <div className="line-clamp-1 flex h-40 w-full items-center gap-8 bg-grey-50 px-24">
+        <SmallBusIcon />
+        <span className="text-12 font-500 text-grey-600">
+          수요신청 하신 셔틀 중{' '}
+          <span className="font-600 text-grey-800">1개</span>의 셔틀이 예약 진행
+          중입니다.
+        </span>
+      </div>
+      {children}
+      <div className="mt-12 h-8 w-full bg-grey-50" />
+    </>
+  );
+};

--- a/src/app/mypage/shuttle/components/tabs/DemandTab.tsx
+++ b/src/app/mypage/shuttle/components/tabs/DemandTab.tsx
@@ -5,7 +5,7 @@ import SmallBusIcon from 'public/icons/bus-small.svg';
 import { ShuttleDemandType } from '@/types/client.types';
 import DemandCard from '../DemandCard';
 import { ID_TO_REGION } from '@/constants/regions';
-import { getRoutes } from '@/services/shuttleOperation';
+import { getRoutes, useDeleteDemand } from '@/services/shuttleOperation';
 
 interface Props {
   demands: ShuttleDemandType[];
@@ -28,10 +28,11 @@ const DemandTab = ({ demands }: Props) => {
     return true;
   });
 
+  const { mutate: deleteDemand } = useDeleteDemand();
+
   return (
     <ul>
       <ReservationOngoingWrapper>
-        <div />
         {reservationOngoingDemands.map((demand) => (
           <DemandCard
             key={demand.id}
@@ -47,7 +48,11 @@ const DemandTab = ({ demands }: Props) => {
           demand={demand}
           subButtonText="신청 취소"
           subButtonOnClick={() => {
-            console.log('신청 취소');
+            deleteDemand({
+              shuttleID: demand.shuttle.id,
+              dailyShuttleID: demand.dailyShuttleID,
+              ID: demand.id,
+            });
           }}
         />
       ))}

--- a/src/app/mypage/shuttle/components/tabs/DemandTab.tsx
+++ b/src/app/mypage/shuttle/components/tabs/DemandTab.tsx
@@ -1,33 +1,34 @@
 import { ReactNode } from 'react';
-import ShuttleCard from '../ShuttleCard';
-import { MOCK_SHUTTLE_DATA } from '../ShuttleCard';
 import SmallBusIcon from 'public/icons/bus-small.svg';
+import { ShuttleDemandType } from '@/types/client.types';
+import DemandCard from '../DemandCard';
 
-const DemandTab = () => {
+interface Props {
+  demands: ShuttleDemandType[];
+}
+
+const DemandTab = ({ demands }: Props) => {
   return (
     <ul>
       <ReservationOngoingWrapper>
-        <ShuttleCard
+        <div />
+        {/* <ShuttleCard
           id={1}
           data={MOCK_SHUTTLE_DATA}
           buttonText="현재 예약이 진행되고 있는 셔틀이 있어요!"
           buttonHref="/shuttle-detail"
-        />
+        /> */}
       </ReservationOngoingWrapper>
-      <ShuttleCard
-        id={1}
-        data={MOCK_SHUTTLE_DATA}
-        subButtonText="예약 상세보기"
-        subButtonHref="/mypage/shuttle/1"
-      />
-      <ShuttleCard
-        id={1}
-        data={MOCK_SHUTTLE_DATA}
-        buttonText="후기 작성하기"
-        buttonHref="/mypage/reviews/write"
-        subButtonText="예약 상세보기"
-        subButtonHref="/mypage/shuttle/1/"
-      />
+      {demands.map((demand) => (
+        <DemandCard
+          key={demand.id}
+          demand={demand}
+          subButtonText="신청 취소"
+          subButtonOnClick={() => {
+            console.log('신청 취소');
+          }}
+        />
+      ))}
     </ul>
   );
 };

--- a/src/app/mypage/shuttle/components/tabs/DemandTab.tsx
+++ b/src/app/mypage/shuttle/components/tabs/DemandTab.tsx
@@ -46,7 +46,9 @@ const DemandTab = ({ demands }: Props) => {
         <DemandCard
           key={demand.id}
           demand={demand}
-          subButtonText="신청 취소"
+          subButtonText={
+            demand.status === 'OPEN' ? '신청 취소' : '수요조사 확인 종료'
+          }
           subButtonOnClick={() => {
             deleteDemand({
               shuttleID: demand.shuttle.id,
@@ -54,6 +56,7 @@ const DemandTab = ({ demands }: Props) => {
               ID: demand.id,
             });
           }}
+          subButtonDisabled={demand.status !== 'OPEN'}
         />
       ))}
     </ul>

--- a/src/app/mypage/shuttle/components/tabs/PastTab.tsx
+++ b/src/app/mypage/shuttle/components/tabs/PastTab.tsx
@@ -1,22 +1,30 @@
-import ShuttleCard, { MOCK_SHUTTLE_DATA } from '../ShuttleCard';
+import { ReservationType } from '@/types/client.types';
+import ReservationCard from '../ReservationCard';
 
-const PastTab = () => {
+interface Props {
+  reservations: ReservationType[];
+}
+
+const PastTab = ({ reservations }: Props) => {
   return (
     <ul>
-      <ShuttleCard
-        id={1}
-        data={MOCK_SHUTTLE_DATA}
-        subButtonText="예약 상세보기"
-        subButtonHref="/mypage/shuttle/1"
-      />
-      <ShuttleCard
-        id={1}
-        data={MOCK_SHUTTLE_DATA}
-        buttonText="후기 작성하기"
-        buttonHref="/mypage/reviews/write"
-        subButtonText="예약 상세보기"
-        subButtonHref="/mypage/shuttle/1/"
-      />
+      {reservations.map((reservation) => (
+        <ReservationCard
+          key={reservation.id}
+          reservation={reservation}
+          buttonText={
+            reservation.hasReview ? '작성한 후기 보기' : '후기 작성하기'
+          }
+          // TODO: 후기 작성 및 조회 href 변경
+          buttonHref={
+            reservation.hasReview
+              ? '/mypage/reviews'
+              : `/mypage/reviews/write/${reservation.id}`
+          }
+          subButtonText="예약 상세보기"
+          subButtonHref={`/mypage/shuttle/${reservation.id}`}
+        />
+      ))}
     </ul>
   );
 };

--- a/src/app/mypage/shuttle/components/tabs/PastTab.tsx
+++ b/src/app/mypage/shuttle/components/tabs/PastTab.tsx
@@ -1,0 +1,24 @@
+import ShuttleCard, { MOCK_SHUTTLE_DATA } from '../ShuttleCard';
+
+const PastTab = () => {
+  return (
+    <ul>
+      <ShuttleCard
+        id={1}
+        data={MOCK_SHUTTLE_DATA}
+        subButtonText="예약 상세보기"
+        subButtonHref="/mypage/shuttle/1"
+      />
+      <ShuttleCard
+        id={1}
+        data={MOCK_SHUTTLE_DATA}
+        buttonText="후기 작성하기"
+        buttonHref="/mypage/reviews/write"
+        subButtonText="예약 상세보기"
+        subButtonHref="/mypage/shuttle/1/"
+      />
+    </ul>
+  );
+};
+
+export default PastTab;

--- a/src/app/mypage/shuttle/constants/shuttle.constants.ts
+++ b/src/app/mypage/shuttle/constants/shuttle.constants.ts
@@ -1,0 +1,52 @@
+export type StatusType =
+  | '수요 확인 중'
+  | '수요 신청 마감'
+  | '예약 모집 중'
+  | '예약 모집 마감'
+  | '배차 확정'
+  | '운행 종료'
+  | '무산'
+  | '비활성';
+
+export const STATUS_STYLE = {
+  fullGreen: {
+    dot: 'bg-primary-main',
+    text: 'text-primary-main',
+  },
+  emptyGreen: {
+    dot: 'border-2 border-primary-main',
+    text: 'text-primary-main',
+  },
+  darkGrey: {
+    dot: 'bg-grey-700',
+    text: 'text-grey-700',
+  },
+  lightGrey: {
+    dot: 'bg-grey-500',
+    text: 'text-grey-500',
+  },
+};
+
+export const RESERVATION_STATUS_TEXT = {
+  OPEN: '예약 모집 중',
+  CLOSED: '예약 모집 마감',
+  CONFIRMED: '배차 확정',
+  ENDED: '운행 종료',
+  CANCELLED: '무산',
+  INACTIVE: '비활성',
+} as const;
+
+export const DEMAND_STATUS_TEXT = {
+  OPEN: '수요 확인 중',
+  CLOSED: '수요 신청 마감',
+  SHUTTLE_ASSIGNED: '수요 신청 마감',
+  ENDED: '운행 종료',
+  CANCELLED: '무산',
+  INACTIVE: '비활성',
+} as const;
+
+export const TRIP_TEXT = {
+  TO_DESTINATION: '콘서트행',
+  FROM_DESTINATION: '귀가행',
+  ROUND_TRIP: '왕복',
+} as const;

--- a/src/app/mypage/shuttle/page.tsx
+++ b/src/app/mypage/shuttle/page.tsx
@@ -3,9 +3,9 @@
 import AppBar from '@/components/app-bar/AppBar';
 import Tabs from '@/components/tab/Tabs';
 import { useRouter } from 'next/navigation';
-import ShuttleCard, { MOCK_SHUTTLE_DATA } from './components/ShuttleCard';
-import { ReactNode } from 'react';
-import SmallBusIcon from 'public/icons/bus-small.svg';
+import CurrentTab from './components/tabs/CurrentTab';
+import DemandTab from './components/tabs/DemandTab';
+import PastTab from './components/tabs/PastTab';
 
 type TabType = 'current' | 'demand' | 'past';
 
@@ -17,6 +17,17 @@ interface Props {
 
 const Shuttle = ({ searchParams }: Props) => {
   const router = useRouter();
+
+  const renderTab = () => {
+    switch (searchParams.type) {
+      case 'current':
+        return <CurrentTab />;
+      case 'demand':
+        return <DemandTab />;
+      case 'past':
+        return <PastTab />;
+    }
+  };
 
   return (
     <>
@@ -35,56 +46,10 @@ const Shuttle = ({ searchParams }: Props) => {
             }}
           />
         </div>
-        <ul>
-          <ReservationOngoingWrapper>
-            <ShuttleCard
-              id={1}
-              data={MOCK_SHUTTLE_DATA}
-              buttonText="현재 예약이 진행되고 있는 셔틀이 있어요!"
-              buttonHref="/shuttle-detail"
-            />
-          </ReservationOngoingWrapper>
-          <ShuttleCard
-            id={1}
-            data={MOCK_SHUTTLE_DATA}
-            subButtonText="예약 상세보기"
-            subButtonHref="/mypage/shuttle/1"
-          />
-          <ShuttleCard
-            id={1}
-            data={MOCK_SHUTTLE_DATA}
-            buttonText="후기 작성하기"
-            buttonHref="/mypage/reviews/write"
-            subButtonText="예약 상세보기"
-            subButtonHref="/mypage/shuttle/1/"
-          />
-        </ul>
+        {renderTab()}
       </main>
     </>
   );
 };
 
 export default Shuttle;
-
-interface ReservationOngoingWrapperProps {
-  children: ReactNode;
-}
-
-const ReservationOngoingWrapper = ({
-  children,
-}: ReservationOngoingWrapperProps) => {
-  return (
-    <>
-      <div className="line-clamp-1 flex h-40 w-full items-center gap-8 bg-grey-50 px-24">
-        <SmallBusIcon />
-        <span className="text-12 font-500 text-grey-600">
-          수요신청 하신 셔틀 중{' '}
-          <span className="font-600 text-grey-800">1개</span>의 셔틀이 예약 진행
-          중입니다.
-        </span>
-      </div>
-      {children}
-      <div className="mt-12 h-8 w-full bg-grey-50" />
-    </>
-  );
-};

--- a/src/app/mypage/shuttle/page.tsx
+++ b/src/app/mypage/shuttle/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import CurrentTab from './components/tabs/CurrentTab';
 import DemandTab from './components/tabs/DemandTab';
 import PastTab from './components/tabs/PastTab';
+import { useGetUserDashboard } from '@/services/users';
 
 type TabType = 'current' | 'demand' | 'past';
 
@@ -17,15 +18,22 @@ interface Props {
 
 const Shuttle = ({ searchParams }: Props) => {
   const router = useRouter();
+  const { data: userDashboard } = useGetUserDashboard();
 
   const renderTab = () => {
     switch (searchParams.type) {
       case 'current':
-        return <CurrentTab />;
+        return (
+          <CurrentTab
+            reservations={userDashboard?.reservations.current ?? []}
+          />
+        );
       case 'demand':
-        return <DemandTab />;
+        return <DemandTab demands={userDashboard?.shuttleDemands ?? []} />;
       case 'past':
-        return <PastTab />;
+        return (
+          <PastTab reservations={userDashboard?.reservations.past ?? []} />
+        );
     }
   };
 

--- a/src/services/shuttleOperation.ts
+++ b/src/services/shuttleOperation.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { instance } from './config';
-import { ArtistType } from '@/types/client.types';
+import { ArtistType, RouteStatusType, RouteType } from '@/types/client.types';
 
 const getArtists = async () => {
   const res = await instance.get('/shuttle-operation/artists');
@@ -14,4 +14,31 @@ export const useGetArtists = () => {
     queryFn: getArtists,
     initialData: [],
   });
+};
+
+export const getRoutes = async (
+  shuttleID: number,
+  dailyShuttleID: number,
+  {
+    bigRegion,
+    smallRegion,
+    status = 'OPEN',
+  }: {
+    bigRegion?: string;
+    smallRegion?: string;
+    status?: RouteStatusType;
+  },
+) => {
+  const res = await instance.get(
+    `/shuttle-operation/shuttles/${shuttleID}/dates/${dailyShuttleID}/routes`,
+    {
+      params: {
+        bigRegion,
+        smallRegion,
+        status,
+      },
+    },
+  );
+  const data: RouteType[] = res.data?.shuttleRouteDetails;
+  return data;
 };

--- a/src/services/shuttleOperation.ts
+++ b/src/services/shuttleOperation.ts
@@ -1,6 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { instance } from './config';
 import { ArtistType, RouteStatusType, RouteType } from '@/types/client.types';
+import { toast } from 'react-toastify';
 
 const getArtists = async () => {
   const res = await instance.get('/shuttle-operation/artists');
@@ -41,4 +42,32 @@ export const getRoutes = async (
   );
   const data: RouteType[] = res.data?.shuttleRouteDetails;
   return data;
+};
+
+export const deleteDemand = async ({
+  shuttleID,
+  dailyShuttleID,
+  ID,
+}: {
+  shuttleID: number;
+  dailyShuttleID: number;
+  ID: number;
+}) => {
+  return await instance.delete(
+    `/shuttle-operation/shuttles/${shuttleID}/dates/${dailyShuttleID}/demands/${ID}`,
+  );
+};
+
+export const useDeleteDemand = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteDemand,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+      toast.success('수요조사를 취소했습니다.');
+    },
+    onError: () => {
+      toast.error('수요조사 취소에 실패했습니다.');
+    },
+  });
 };

--- a/src/types/client.types.ts
+++ b/src/types/client.types.ts
@@ -101,13 +101,17 @@ export type HandyStatusType =
   | 'DECLINED'
   | 'ACCEPTED';
 
+export type TripType = 'TO_DESTINATION' | 'FROM_DESTINATION' | 'ROUND_TRIP';
+
 export interface ShuttleDemandType {
   id: number;
   shuttle: ShuttleType;
-  type: 'TO_DESTINATION' | 'FROM_DESTINATION' | 'ROUND_TRIP';
+  type: TripType;
   status: ShuttleDemandStatusType;
   passengerCount: number;
-  region: RegionType;
+  regionID: number;
+  dailyShuttleID: number;
+  createdAt: string;
 }
 
 type BaseReservationType = {
@@ -117,6 +121,8 @@ type BaseReservationType = {
   cancelStatus: CancelStatusType;
   handyStatus: HandyStatusType;
   payment: PaymentType;
+  createdAt: string;
+  type: TripType;
 };
 
 type ReservationWithReview = BaseReservationType & {
@@ -137,6 +143,7 @@ export interface ShuttleType {
   date: string;
   image: string;
   destination: DestinationType;
+  route?: RouteType;
 }
 
 export type ShuttleWithRouteType = ShuttleType & { route: RouteType };

--- a/src/types/client.types.ts
+++ b/src/types/client.types.ts
@@ -1,5 +1,6 @@
 import { BigRegionsType } from '@/constants/regions';
 
+//  --- 유저 관련 타입 ---
 export type AgeType =
   | '연령대 미지정'
   | '10대 이하'
@@ -41,118 +42,6 @@ export interface ArtistType {
   name: string;
 }
 
-export interface RegionType {
-  id: number;
-  provinceFullName: BigRegionsType;
-  provinceShortName: string;
-  cityFullName: string;
-  cityShortName: string;
-}
-
-export interface HubType {
-  name: string;
-  sequence: number;
-  arrivalTime: string;
-  selected: boolean;
-}
-
-export interface RouteType {
-  name: string;
-  hubs: {
-    pickup: HubType[];
-    dropoff: HubType[];
-    destination: HubType;
-  };
-}
-
-export interface PaymentType {
-  id: number;
-  principalAmount: number;
-  paymentAmount: number;
-  discountAmount: number;
-}
-
-export type ReservationStatusType =
-  | 'NOT_PAYMENT'
-  | 'COMPLETE_PAYMENT'
-  | 'RESERVATION_CONFIRM'
-  | 'CANCEL';
-export type CancelStatusType = 'NONE' | 'CANCEL_REQUEST' | 'CANCEL_COMPLETE';
-export type HandyStatusType =
-  | 'NOT_SUPPORTED'
-  | 'SUPPORTED'
-  | 'DECLINED'
-  | 'ACCEPTED';
-
-type BaseReservationType = {
-  id: number;
-  shuttle: ShuttleType;
-  reservationStatus: ReservationStatusType;
-  cancelStatus: CancelStatusType;
-  handyStatus: HandyStatusType;
-  payment: PaymentType;
-};
-
-type ReservationWithReview = BaseReservationType & {
-  hasReview: true;
-  review: ReviewType;
-};
-
-type ReservationWithoutReview = BaseReservationType & {
-  hasReview: false;
-};
-
-export type ReservationType = ReservationWithReview | ReservationWithoutReview;
-
-export interface DestinationType {
-  name: string;
-  longitude: number;
-  latitude: number;
-}
-
-export interface ShuttleType {
-  id: number;
-  name: string;
-  date: string;
-  image: string;
-  destination: DestinationType;
-  route: RouteType;
-}
-
-export interface ReviewType {
-  id: number;
-  shuttle: ShuttleType;
-  rating: number;
-  content: string;
-  images: string[];
-  createdAt: string;
-}
-
-export type ShuttleDemandStatusType =
-  | 'OPEN'
-  | 'CLOSED'
-  | 'SHUTTLE_ASSIGNED'
-  | 'ENDED'
-  | 'CANCELLED'
-  | 'INACTIVE';
-
-export interface ShuttleDemandType {
-  id: number;
-  shuttle: ShuttleType;
-  type: 'TO_DESTINATION' | 'FROM_DESTINATION' | 'ROUND_TRIP';
-  status: ShuttleDemandStatusType;
-  passengerCount: number;
-  region: RegionType;
-}
-
-export interface CouponType {
-  id: number;
-  name: string;
-  description: string;
-}
-
-export type AuthChannelType = 'NONE' | 'kakao' | 'naver';
-
 export interface UserDashboardType {
   id: number;
   nickname: string;
@@ -173,4 +62,141 @@ export interface UserDashboardType {
   favoriteArtists: ArtistType[];
   shuttleDemands: ShuttleDemandType[];
   coupons: CouponType[];
+}
+
+// --- 셔틀 및 노선 관련 타입 ---
+export type ShuttleDemandStatusType =
+  | 'OPEN' // 수요조사가 아직 모집 중인 상태
+  | 'CLOSED' // 수요조사 모집 종료, 셔틀 미매핑 상태
+  | 'SHUTTLE_ASSIGNED' // 수요조사 모집 종료, 셔틀 매핑 상태
+  | 'ENDED' // 콘서트가 끝나 셔틀 운행 종료
+  | 'CANCELLED' // 무산 상태
+  | 'INACTIVE';
+
+export type ShuttleStatusType =
+  | 'OPEN' // 셔틀 열린 상태
+  | 'CLOSED' // 셔틀의 모든 일자에 대한 수요조사 모집 종료
+  | 'ENDED' // 셔틀 종료됨
+  | 'INACTIVE';
+
+export type RouteStatusType =
+  | 'OPEN' // 예약모집중
+  | 'CLOSED' // 예약마감
+  | 'CONFIRMED' // 배차가 완료되고 모든 정보가 확정된 상태
+  | 'ENDED' // 운행종료
+  | 'CANCELLED' // 무산
+  | 'INACTIVE'; // 비활성
+
+export type ReservationStatusType =
+  | 'NOT_PAYMENT' // 결제 전
+  | 'COMPLETE_PAYMENT' // 결제 완료
+  | 'RESERVATION_CONFIRM' // 예약 확정
+  | 'CANCEL'; // 예약 취소
+
+export type CancelStatusType = 'NONE' | 'CANCEL_REQUEST' | 'CANCEL_COMPLETE';
+
+export type HandyStatusType =
+  | 'NOT_SUPPORTED'
+  | 'SUPPORTED'
+  | 'DECLINED'
+  | 'ACCEPTED';
+
+export interface ShuttleDemandType {
+  id: number;
+  shuttle: ShuttleType;
+  type: 'TO_DESTINATION' | 'FROM_DESTINATION' | 'ROUND_TRIP';
+  status: ShuttleDemandStatusType;
+  passengerCount: number;
+  region: RegionType;
+}
+
+type BaseReservationType = {
+  id: number;
+  shuttle: ShuttleWithRouteType;
+  reservationStatus: ReservationStatusType;
+  cancelStatus: CancelStatusType;
+  handyStatus: HandyStatusType;
+  payment: PaymentType;
+};
+
+type ReservationWithReview = BaseReservationType & {
+  hasReview: true;
+  review: Omit<ReviewType, 'shuttle'>;
+};
+
+type ReservationWithoutReview = BaseReservationType & {
+  hasReview: false;
+};
+
+export type ReservationType = ReservationWithReview | ReservationWithoutReview;
+
+export interface ShuttleType {
+  id: number;
+  name: string;
+  status: ShuttleStatusType;
+  date: string;
+  image: string;
+  destination: DestinationType;
+}
+
+export type ShuttleWithRouteType = ShuttleType & { route: RouteType };
+
+export interface RouteType {
+  name: string;
+  status: RouteStatusType;
+  hubs: {
+    pickup: HubType[];
+    dropoff: HubType[];
+  };
+}
+
+export interface DestinationType {
+  name: string;
+  longitude: number;
+  latitude: number;
+}
+
+export interface ImageType {
+  imageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ReviewType {
+  id: number;
+  shuttle: ShuttleType;
+  rating: number;
+  content: string;
+  images: ImageType[];
+  createdAt: string;
+}
+
+export interface CouponType {
+  id: number;
+  name: string;
+  description: string;
+}
+
+export type AuthChannelType = 'NONE' | 'kakao' | 'naver';
+
+export interface RegionType {
+  id: number;
+  provinceFullName: BigRegionsType;
+  provinceShortName: string;
+  cityFullName: string;
+  cityShortName: string;
+}
+
+export interface HubType {
+  name: string;
+  sequence: number;
+  arrivalTime: string;
+  selected: boolean;
+}
+
+export interface PaymentType {
+  id: number;
+  principalAmount: number;
+  paymentAmount: number;
+  discountAmount: number;
 }


### PR DESCRIPTION
## 개요

마이페이지 - 셔틀 페이지를 구현 및 api을 연결했습니다.

## 변경사항

마이페이지에서 유저가 신청한 수요조사 및 예약 내역을 확인할 수 있는 탭들을 구현했습니다.

## 기타 사항
- 유저별 예약 및 수요조사 생성을 아직 할 수 없어서 테스트를 해보지 못했습니다. 추후 어드민 페이지가 완성되면 테스팅하도록 하겠습니다.
- 예약 관련 페이지(예약 상세 페이지, 핸디 지원 페이지, 환불 내역 페이지)들의 기획이 변경되며 규모가 커져서 추후에 다른 PR로 올리도록 하겠습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).