### PR TITLE
feat(마이페이지-셔틀): 예약 상세보기 및 핸디 가이드 페이지 마크업

### DIFF
--- a/src/app/help/what-is-handy/page.tsx
+++ b/src/app/help/what-is-handy/page.tsx
@@ -6,7 +6,7 @@ import ToastyCheck from 'public/icons/toasty-check.svg';
 const AboutPage = () => {
   return (
     <>
-      <AppBar>핸디버스 소개</AppBar>
+      <AppBar>핸디란?</AppBar>
       <main className="w-full flex-grow pb-12">
         <Article titleSize="large" richTitle="핸디버스의 ‘핸디’란?">
           <p className="w-full flex-col gap-8 px-16 pt-12 text-16 font-500 text-grey-700">

--- a/src/app/mypage/shuttle/[id]/handy/page.tsx
+++ b/src/app/mypage/shuttle/[id]/handy/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import AppBar from '@/components/app-bar/AppBar';
+import Button from '@/components/buttons/button/Button';
+import TextInput from '@/components/inputs/text-input/TextInput';
+import Link from 'next/link';
+import { useForm } from 'react-hook-form';
+
+const Handy = () => {
+  const { control, setValue } = useForm({
+    defaultValues: {
+      link: '',
+    },
+  });
+
+  return (
+    <>
+      <AppBar>핸디 가이드</AppBar>
+      <main className="px-16">
+        <section className="pt-[60px]">
+          <h2 className="pb-12 text-28 font-700">‘핸디’ 가이드를 전달드려요</h2>
+          <p className="pb-12 text-16 font-400 text-grey-700">
+            이번 셔틀 운행 간 <span className="font-600">‘핸디’</span>로
+            지원해주셔서 감사드리며, 선정을 축하합니다!
+            <br />
+            <br />
+            핸디버스의 ‘핸디’는 안전한 셔틀 운행을 위한{' '}
+            <span className="font-600">현장 도우미</span>예요.
+            <br />
+            <br />
+            자세한 핸디 가이드는 아래 링크를 확인해주세요!
+          </p>
+          <Link
+            href="/help/what-is-handy"
+            className="mx-auto mt-[60px] block w-fit rounded-full bg-grey-100 px-16 text-grey-600-sub"
+          >
+            핸디 가이드 보러가기
+          </Link>
+        </section>
+        <section className="py-[60px]">
+          <h2 className="pb-12 text-28 font-700">오픈채팅방 링크 입력</h2>
+          <p className="pb-24 text-16 font-400 text-grey-700">
+            개설한 오픈채팅방으로 다른 탑승객분들이 입장할 수 있도록 링크를
+            입력해주세요.
+            <br />
+            <br />
+            자세한 개설 방법은 ‘핸디 가이드 보러가기’에서 확인하실 수 있어요.
+          </p>
+          <form className="flex flex-col gap-12">
+            <TextInput
+              name="link"
+              control={control}
+              setValue={setValue}
+              placeholder="오픈채팅방 링크를 입력해주세요"
+            >
+              링크 입력
+            </TextInput>
+            <Button>링크 제출하기</Button>
+          </form>
+        </section>
+      </main>
+    </>
+  );
+};
+
+export default Handy;

--- a/src/app/mypage/shuttle/[id]/page.tsx
+++ b/src/app/mypage/shuttle/[id]/page.tsx
@@ -3,7 +3,9 @@
 import { ReactNode, useState } from 'react';
 import Section from '../components/Section';
 import Button from '@/components/buttons/button/Button';
-import NoticeSection from '@/components/notice-section/NoticeSection';
+import NoticeSection, {
+  CancellationAndRefundContent,
+} from '@/components/notice-section/NoticeSection';
 import AppBar from '@/components/app-bar/AppBar';
 import Link from 'next/link';
 import Divider from '../components/Divider';
@@ -43,7 +45,7 @@ const ShuttleDetail = ({ params }: Props) => {
             ___(닉네임) 님은 이번 셔틀의 핸디로 선정되셨습니다.
           </p>
           <Link
-            href={'/'}
+            href={`/mypage/shuttle/${id}/handy`}
             className="ml-auto mt-8 block w-fit rounded-full bg-grey-100 px-16 text-14 font-400 text-grey-600-sub"
           >
             핸디 가이드 보러가기
@@ -140,10 +142,10 @@ const ShuttleDetail = ({ params }: Props) => {
           </div>
           <div className="flex w-full gap-4 pb-24">
             <div>할인 금액</div>
-            <div className="grow text-right font-500">0원</div>
+            <div className="grow text-right">0원</div>
           </div>
           <div className="flex w-full gap-4">
-            <div className="text-18 font-500">최종 결제 금액</div>
+            <div className="text-18">최종 결제 금액</div>
             <div className="grow text-right text-22 font-600">104,000원</div>
           </div>
         </Section>
@@ -155,6 +157,31 @@ const ShuttleDetail = ({ params }: Props) => {
         </Section>
         <Divider />
         <NoticeSection type="term-and-condition" />
+        <Section title="취소 신청 정보">
+          <div className="flex flex-col gap-8">
+            <DetailRow title="신청 일시" content="2024-10-14 20:49:48" />
+            <DetailRow title="완료 일시" content="2024-10-14 20:49:48" />
+          </div>
+        </Section>
+        <Section title="환불 정보">
+          <div className="flex flex-col gap-8 text-grey-900">
+            <div className="flex w-full gap-4">
+              <div>결제 금액</div>
+              <div className="grow text-right">104,000원</div>
+            </div>
+            <div className="flex w-full gap-4">
+              <div>수수료</div>
+              <div className="grow text-right">-0원</div>
+            </div>
+            <div className="flex w-full gap-4 pt-24">
+              <div className="text-18">환불 금액</div>
+              <div className="grow text-right text-22 font-600">104,000원</div>
+            </div>
+          </div>
+        </Section>
+        <Section title="취소 및 환불 안내">
+          <CancellationAndRefundContent />
+        </Section>
       </main>
       <HandyRequestModal
         isOpen={isHandyRequestModalOpen}

--- a/src/app/mypage/shuttle/[id]/page.tsx
+++ b/src/app/mypage/shuttle/[id]/page.tsx
@@ -1,4 +1,6 @@
-import { ReactNode } from 'react';
+'use client';
+
+import { ReactNode, useState } from 'react';
 import Section from '../components/Section';
 import Button from '@/components/buttons/button/Button';
 import NoticeSection from '@/components/notice-section/NoticeSection';
@@ -8,6 +10,9 @@ import Divider from '../components/Divider';
 import RefundPolicy from '../components/RefundPolicy';
 import { SECTION } from '@/types/shuttle.types';
 import ShuttleRouteVisualizer from '@/components/shuttle/shuttle-route-visualizer/ShuttleRouteVisualizer';
+import ReservationCard from '../components/ReservationCard';
+import { ReservationType } from '@/types/client.types';
+import HandyRequestModal from '@/components/modals/handy-request/HandyRequestModal';
 
 interface Props {
   params: {
@@ -17,12 +22,46 @@ interface Props {
 
 const ShuttleDetail = ({ params }: Props) => {
   const { id } = params;
+  const [isHandyRequestModalOpen, setIsHandyRequestModalOpen] = useState(false);
+  const handleHandyRequestConfirm = () => {
+    setIsHandyRequestModalOpen(false);
+  };
+  const handleHandyRequestClosed = () => {
+    setIsHandyRequestModalOpen(false);
+  };
   return (
     <>
       <AppBar>예약 상세 보기</AppBar>
       <main className="grow">
-        {/* <ShuttleCard id={1} data={MOCK_SHUTTLE_DATA} /> */}
-        <Section title="당신은 핸디입니다~">TODO</Section>
+        <ReservationCard reservation={MOCK_RESERVATION_DATA} />
+        <section className="m-16 rounded-[10px] bg-primary-50 p-16 text-14 font-400 text-grey-800">
+          현재 셔틀 정보, 기사님 정보, 핸디 정보 등을 결정하고 있어요. 확정되면
+          알림톡을 전송해드릴게요.
+        </section>
+        <Section title="당신은 핸디입니다">
+          <p className="pt-4 text-12 font-400 text-grey-500">
+            ___(닉네임) 님은 이번 셔틀의 핸디로 선정되셨습니다.
+          </p>
+          <Link
+            href={'/'}
+            className="ml-auto mt-8 block w-fit rounded-full bg-grey-100 px-16 text-14 font-400 text-grey-600-sub"
+          >
+            핸디 가이드 보러가기
+          </Link>
+        </Section>
+        <Section title="셔틀 정보">
+          <div className="flex flex-col gap-8">
+            <DetailRow title="차량 종류" content="28인승 우등버스" />
+            <DetailRow title="배정 호차" content="2호차" />
+            <DetailRow title="차량 번호" content="충북76바 3029" />
+            <DetailRow
+              title="오픈채팅방 링크"
+              content="https://openchat.example.com"
+            />
+            <DetailRow title="핸디 정보" content="나핸디할래요" />
+            <DetailRow title="전화번호" content="010-1234-5678" />
+          </div>
+        </Section>
         <Section title="예약 정보">
           <div className="flex flex-col gap-28">
             <section className="flex flex-col gap-8">
@@ -51,8 +90,30 @@ const ShuttleDetail = ({ params }: Props) => {
               />
               <DetailRow title="탑승객 수" content="2명" />
             </section>
-            <Passenger index={1} name="홍길동" phoneNumber="010-1234-5678" />
+            <Passenger
+              index={1}
+              name="홍길동"
+              phoneNumber="010-1234-5678"
+              tagText="핸디 지원"
+            />
             <Passenger index={2} name="홍길동" phoneNumber="010-1234-5678" />
+            <div className="flex flex-col gap-8">
+              <button
+                onClick={() => setIsHandyRequestModalOpen(true)}
+                className="ml-auto block w-fit rounded-full bg-grey-100 px-16 text-14 font-400 text-grey-600-sub"
+              >
+                핸디 지원/취소하기
+              </button>
+              <p className="text-right text-12 font-400 text-grey-500">
+                핸디는 탑승객1(직접 신청자)만 지원이 가능합니다.{' '}
+                <Link
+                  href="/help/what-is-handy"
+                  className="text-right text-12 font-400 text-grey-500 underline"
+                >
+                  핸디 더 알아보기
+                </Link>
+              </p>
+            </div>
           </div>
         </Section>
         <Divider />
@@ -95,6 +156,12 @@ const ShuttleDetail = ({ params }: Props) => {
         <Divider />
         <NoticeSection type="term-and-condition" />
       </main>
+      <HandyRequestModal
+        isOpen={isHandyRequestModalOpen}
+        onConfirm={handleHandyRequestConfirm}
+        onClosed={handleHandyRequestClosed}
+        buttonText="지원/취소하기"
+      />
     </>
   );
 };
@@ -119,14 +186,104 @@ interface PassengerProps {
   index: number;
   name: string;
   phoneNumber: string;
+  tagText?: string;
 }
 
-const Passenger = ({ index, name, phoneNumber }: PassengerProps) => {
+const Passenger = ({ index, name, phoneNumber, tagText }: PassengerProps) => {
   return (
     <section className="flex flex-col gap-8">
-      <h4 className="pb-4 text-18 font-500 text-grey-700">탑승객 {index}</h4>
+      <h4 className="flex items-center gap-8 pb-4 text-18 font-500 text-grey-700">
+        탑승객 {index}
+        {tagText && (
+          <div className="rounded-full border border-grey-100 px-8 text-12 font-400 text-grey-600-sub">
+            {tagText}
+          </div>
+        )}
+      </h4>
       <DetailRow title="이름" content={name} />
       <DetailRow title="전화번호" content={phoneNumber} />
     </section>
   );
+};
+
+const MOCK_RESERVATION_DATA: ReservationType = {
+  id: 0,
+  shuttle: {
+    id: 0,
+    name: 'string',
+    date: 'string',
+    image:
+      'https://talkimg.imbc.com/TVianUpload/tvian/TViews/image/2022/08/19/c5cd0937-06c6-4f4c-9f22-660c5ec8adfb.jpg',
+    status: 'OPEN',
+    destination: {
+      name: 'string',
+      longitude: 0,
+      latitude: 0,
+    },
+    route: {
+      name: 'string',
+      status: 'OPEN',
+      hubs: {
+        pickup: [
+          {
+            name: 'string',
+            sequence: 0,
+            arrivalTime: 'string',
+            selected: true,
+          },
+        ],
+        dropoff: [
+          {
+            name: 'string',
+            sequence: 0,
+            arrivalTime: 'string',
+            selected: true,
+          },
+        ],
+      },
+    },
+  },
+  hasReview: true,
+  review: {
+    id: 0,
+    rating: 0,
+    content: 'string',
+    images: [
+      {
+        imageUrl: 'https://example.com/image.jpg',
+        status: 'ACTIVE',
+        createdAt: 'string',
+        updatedAt: 'string',
+      },
+    ],
+    createdAt: 'string',
+  },
+  type: 'TO_DESTINATION',
+  reservationStatus: 'NOT_PAYMENT',
+  cancelStatus: 'NONE',
+  handyStatus: 'NOT_SUPPORTED',
+  passengers: [
+    {
+      name: 'string',
+      phoneNumber: 'string',
+    },
+  ],
+  payment: {
+    id: 0,
+    principalAmount: 0,
+    paymentAmount: 0,
+    discountAmount: 0,
+  },
+  shuttleBus: {
+    shuttleBusID: 1,
+    shuttleRouteID: 100,
+    handyUserID: 100,
+    type: 'SEATER_12',
+    name: '스타렉스',
+    number: '12가 3456',
+    phoneNumber: '010-1234-5678',
+    openChatLink: 'https://openchat.example.com',
+    capacity: 12,
+  },
+  createdAt: 'string',
 };

--- a/src/app/mypage/shuttle/components/DemandCard.tsx
+++ b/src/app/mypage/shuttle/components/DemandCard.tsx
@@ -74,7 +74,7 @@ const DemandCard = ({
         <span className={`font-600 ${statusStyle.text}`}>{status}</span>
         <span className="font-500 text-grey-500">{demand.createdAt} 신청</span>
       </div>
-      <div className="flex h-[110px] w-full gap-16">
+      <div className="flex h-[130px] w-full gap-16">
         <div className="relative h-full w-80 overflow-hidden rounded-[8px]">
           <Image
             src={demand.shuttle.image}
@@ -99,31 +99,33 @@ const DemandCard = ({
           </span>
         </div>
       </div>
-      <div className="flex gap-8">
-        {buttonText && buttonHref && (
-          <button
-            onClick={handleButtonClick(buttonHref)}
-            disabled={buttonDisabled}
-            type="button"
-            className="flex h-40 w-full items-center justify-center rounded-full bg-primary-main text-14 font-500 text-white active:bg-primary-700 disabled:bg-grey-50 disabled:text-grey-300"
-          >
-            {buttonText}
-          </button>
-        )}
-        {subButtonText && (
-          <button
-            onClick={
-              subButtonOnClick ||
-              (subButtonHref ? handleButtonClick(subButtonHref) : undefined)
-            }
-            disabled={subButtonDisabled}
-            type="button"
-            className="flex h-40 w-full items-center justify-center rounded-full bg-grey-50 text-14 font-500 text-grey-700 disabled:bg-grey-50 disabled:text-grey-300"
-          >
-            {subButtonText}
-          </button>
-        )}
-      </div>
+      {(buttonText || subButtonText) && (
+        <div className="flex gap-8">
+          {buttonText && buttonHref && (
+            <button
+              onClick={handleButtonClick(buttonHref)}
+              disabled={buttonDisabled}
+              type="button"
+              className="flex h-40 w-full items-center justify-center rounded-full bg-primary-main text-14 font-500 text-white active:bg-primary-700 disabled:bg-grey-50 disabled:text-grey-300"
+            >
+              {buttonText}
+            </button>
+          )}
+          {subButtonText && (
+            <button
+              onClick={
+                subButtonOnClick ||
+                (subButtonHref ? handleButtonClick(subButtonHref) : undefined)
+              }
+              disabled={subButtonDisabled}
+              type="button"
+              className="flex h-40 w-full items-center justify-center rounded-full bg-grey-50 text-14 font-500 text-grey-700 disabled:bg-grey-50 disabled:text-grey-300"
+            >
+              {subButtonText}
+            </button>
+          )}
+        </div>
+      )}
     </Link>
   );
 };

--- a/src/app/mypage/shuttle/components/ReservationCard.tsx
+++ b/src/app/mypage/shuttle/components/ReservationCard.tsx
@@ -70,7 +70,7 @@ const ReservationCard = ({
           {reservation.createdAt} 예약
         </span>
       </div>
-      <div className="flex h-[110px] w-full gap-16">
+      <div className="flex h-[130px] w-full gap-16">
         <div className="relative h-full w-80 overflow-hidden rounded-[8px]">
           <Image
             src={reservation.shuttle.image}
@@ -100,31 +100,41 @@ const ReservationCard = ({
             {reservation.payment.paymentAmount.toLocaleString()}{' '}
             <span className="text-12">원</span>
           </span>
-          {/* TODO: 핸디 신청 상태 & 환불 신청 상태를 tag로 보여주기 */}
+          <div className="flex gap-8 pt-4">
+            {/* TODO: 핸디 신청 상태 & 환불 신청 상태를 tag로 보여주기 */}
+            <div className="rounded-full border border-grey-400 px-4 text-10 text-grey-500">
+              핸디 지원
+            </div>
+            <div className="rounded-full border border-grey-400 px-4 text-10 text-grey-500">
+              환불 진행 중
+            </div>
+          </div>
         </div>
       </div>
-      <div className="flex gap-8">
-        {buttonText && buttonHref && (
-          <button
-            onClick={handleButtonClick(buttonHref)}
-            disabled={buttonDisabled}
-            type="button"
-            className="flex h-40 w-full items-center justify-center rounded-full bg-primary-main text-14 font-500 text-white active:bg-primary-700 disabled:bg-grey-50 disabled:text-grey-300"
-          >
-            {buttonText}
-          </button>
-        )}
-        {subButtonText && subButtonHref && (
-          <button
-            onClick={handleButtonClick(subButtonHref)}
-            disabled={subButtonDisabled}
-            type="button"
-            className="flex h-40 w-full items-center justify-center rounded-full bg-grey-50 text-14 font-500 text-grey-700 disabled:bg-grey-50 disabled:text-grey-300"
-          >
-            {subButtonText}
-          </button>
-        )}
-      </div>
+      {(buttonText || subButtonText) && (
+        <div className="flex gap-8">
+          {buttonText && buttonHref && (
+            <button
+              onClick={handleButtonClick(buttonHref)}
+              disabled={buttonDisabled}
+              type="button"
+              className="flex h-40 w-full items-center justify-center rounded-full bg-primary-main text-14 font-500 text-white active:bg-primary-700 disabled:bg-grey-50 disabled:text-grey-300"
+            >
+              {buttonText}
+            </button>
+          )}
+          {subButtonText && subButtonHref && (
+            <button
+              onClick={handleButtonClick(subButtonHref)}
+              disabled={subButtonDisabled}
+              type="button"
+              className="flex h-40 w-full items-center justify-center rounded-full bg-grey-50 text-14 font-500 text-grey-700 disabled:bg-grey-50 disabled:text-grey-300"
+            >
+              {subButtonText}
+            </button>
+          )}
+        </div>
+      )}
     </Link>
   );
 };

--- a/src/app/mypage/shuttle/components/Section.tsx
+++ b/src/app/mypage/shuttle/components/Section.tsx
@@ -10,7 +10,7 @@ const Section = ({ children, title }: Props) => {
   return (
     <>
       <Divider />
-      <section className="px-16 py-32 text-16 font-400 text-grey-900">
+      <section className="w-full px-16 py-32 text-16 font-400 text-grey-900">
         <h3 className="mb-8 line-clamp-1 h-32 text-22 font-700">{title}</h3>
         {children}
       </section>

--- a/src/components/modals/handy-request/HandyRequestModal.tsx
+++ b/src/components/modals/handy-request/HandyRequestModal.tsx
@@ -6,16 +6,29 @@ interface Props {
   onConfirm: () => void;
   isOpen: boolean;
   onClosed: () => void;
+  buttonText?: string;
+  subButtonText?: string;
 }
 
-const HandyRequestModal = ({ onConfirm, isOpen, onClosed }: Props) => {
+const HandyRequestModal = ({
+  onConfirm,
+  isOpen,
+  onClosed,
+  buttonText,
+  subButtonText,
+}: Props) => {
   return (
     <CustomModal
       isOpen={isOpen}
       onClosed={onClosed}
       styles="fixed top-50 left-50 z-[101] flex h-[393px] w-280 flex-col items-center justify-center gap-12 bg-white px-24 py-20 rounded-[20px]"
     >
-      <ModalContent onConfirm={onConfirm} onClosed={onClosed} />
+      <ModalContent
+        onConfirm={onConfirm}
+        onClosed={onClosed}
+        buttonText={buttonText}
+        subButtonText={subButtonText}
+      />
     </CustomModal>
   );
 };
@@ -25,9 +38,16 @@ export default HandyRequestModal;
 interface ModalContentProps {
   onConfirm: () => void;
   onClosed: () => void;
+  buttonText?: string;
+  subButtonText?: string;
 }
 
-const ModalContent = ({ onConfirm, onClosed }: ModalContentProps) => {
+const ModalContent = ({
+  onConfirm,
+  onClosed,
+  buttonText = '핸디 역할 알아보기',
+  subButtonText = '아니요, 괜찮아요',
+}: ModalContentProps) => {
   return (
     <>
       <Image
@@ -55,10 +75,10 @@ const ModalContent = ({ onConfirm, onClosed }: ModalContentProps) => {
       </p>
       <div className="flex w-[100%] flex-col gap-8">
         <Button variant="primary" onClick={onConfirm}>
-          핸디 역할 알아보기
+          {buttonText}
         </Button>
         <Button variant="secondary" onClick={onClosed}>
-          아니요, 괜찮아요
+          {subButtonText}
         </Button>
       </div>
     </>

--- a/src/types/client.types.ts
+++ b/src/types/client.types.ts
@@ -120,9 +120,24 @@ type BaseReservationType = {
   reservationStatus: ReservationStatusType;
   cancelStatus: CancelStatusType;
   handyStatus: HandyStatusType;
+  passengers: {
+    name: string;
+    phoneNumber: string;
+  }[];
   payment: PaymentType;
   createdAt: string;
   type: TripType;
+  shuttleBus?: {
+    shuttleBusID: number;
+    shuttleRouteID: number;
+    handyUserID?: number;
+    type: string;
+    name: string;
+    number: string;
+    phoneNumber: string;
+    openChatLink?: string;
+    capacity: number;
+  };
 };
 
 type ReservationWithReview = BaseReservationType & {
@@ -165,6 +180,7 @@ export interface DestinationType {
 
 export interface ImageType {
   imageUrl: string;
+  status: 'ACTIVE' | 'INACTIVE';
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## 개요

예약 상세보기 페이지의 변경사항들을 마크업만 구현해두었습니다.
현재 각 상황에 따른 케이스들을 분리하지 않고 모두 넣어둔 상황입니다. 추후에 api를 연결하면서 케이스에 맞게 분리할 예정입니다.
핸디 가이드 페이지 마크업을 구현했습니다.

## 변경사항


https://github.com/user-attachments/assets/0dabf474-37af-415b-a557-3f149c2aff34



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).