### PR TITLE
fix: 미들웨어에서 access token 만료 핸들링 로직 추가

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,44 +13,34 @@ export const middleware = async (req: NextRequest) => {
 
   // 토큰 만료 시 토큰 재발급
   if (refreshToken && !accessToken) {
-    try {
-      const response = NextResponse.redirect(new URL(req.url));
-      const tokens = await updateToken();
-      response.cookies.set(ACCESS_TOKEN, tokens.accessToken, {
-        ...OPTIONS,
-        expires: new Date(tokens.accessTokenExpiresAt),
-      });
-      response.cookies.set(REFRESH_TOKEN, tokens.refreshToken, {
-        ...OPTIONS,
-        expires: new Date(tokens.refreshTokenExpiresAt),
-      });
-      return response;
-    } catch (error) {
-      console.error('미들웨어 로그인 시간 만료: ', error);
-      const response = NextResponse.redirect(new URL('/login', req.url));
-      response.cookies.delete(ACCESS_TOKEN);
-      response.cookies.delete(REFRESH_TOKEN);
-      return response;
-    }
+    return handleRefreshToken(req);
   }
 
   // 로그인 여부에 따라 리다이렉트
   if (!refreshToken) {
     return NextResponse.redirect(new URL('/login', req.url));
   }
-  const progress = await getProgress();
-  if (
-    progress !== 'ONBOARDING_COMPLETE' &&
-    req.nextUrl.pathname !== '/onboarding'
-  ) {
-    return NextResponse.redirect(new URL('/onboarding', req.url));
+  try {
+    const progress = await getProgress();
+    if (
+      progress !== 'ONBOARDING_COMPLETE' &&
+      req.nextUrl.pathname !== '/onboarding'
+    ) {
+      return NextResponse.redirect(new URL('/onboarding', req.url));
+    }
+  } catch {
+    return handleRefreshToken(req);
   }
 
   // 온보딩을 완료하고 온보딩 페이지 접근 시 마이페이지로 리다이렉트
   if (req.nextUrl.pathname === '/onboarding' && refreshToken) {
-    const progress = await getProgress();
-    if (progress === 'ONBOARDING_COMPLETE') {
-      return NextResponse.redirect(new URL('/mypage', req.url));
+    try {
+      const progress = await getProgress();
+      if (progress === 'ONBOARDING_COMPLETE') {
+        return NextResponse.redirect(new URL('/mypage', req.url));
+      }
+    } catch {
+      return handleRefreshToken(req);
     }
   }
 
@@ -59,4 +49,26 @@ export const middleware = async (req: NextRequest) => {
 
 export const config = {
   matcher: ['/onboarding', '/mypage/:path*', '/demand/:path*/write'],
+};
+
+const handleRefreshToken = async (req: NextRequest) => {
+  try {
+    const response = NextResponse.redirect(new URL(req.url));
+    const tokens = await updateToken();
+    response.cookies.set(ACCESS_TOKEN, tokens.accessToken, {
+      ...OPTIONS,
+      expires: new Date(tokens.accessTokenExpiresAt),
+    });
+    response.cookies.set(REFRESH_TOKEN, tokens.refreshToken, {
+      ...OPTIONS,
+      expires: new Date(tokens.refreshTokenExpiresAt),
+    });
+    return response;
+  } catch (error) {
+    console.error('미들웨어 로그인 시간 만료: ', error);
+    const response = NextResponse.redirect(new URL('/login', req.url));
+    response.cookies.delete(ACCESS_TOKEN);
+    response.cookies.delete(REFRESH_TOKEN);
+    return response;
+  }
 };


### PR DESCRIPTION
## 개요

미들웨어에서 request를 보냈을 때 access token이 만료된 경우 토큰을 업데이트 하는 핸들링 로직을 추가했습니다.
이로 기존에 invalid 한 access token 값을 가지고 인증이 필요한 페이지에 들어갔을 때 문제가 생기던 현상을 해결했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).