### PR TITLE
feat(공통컴포넌트): shuttle route visualizer api response type에 맞게 수정

### DIFF
--- a/src/app/mypage/shuttle/[id]/components/sections/RouteSection.tsx
+++ b/src/app/mypage/shuttle/[id]/components/sections/RouteSection.tsx
@@ -1,20 +1,14 @@
 import ShuttleRouteVisualizer from '@/components/shuttle/shuttle-route-visualizer/ShuttleRouteVisualizer';
 import Divider from '../Divider';
-import { SECTION } from '@/types/shuttle.types';
+import { SECTION, ShuttleRouteHubObject } from '@/types/shuttle.types';
 
 const RouteSection = () => {
   return (
     <>
       <Divider />
       <ShuttleRouteVisualizer
-        object={[
-          { time: '2024-03-20 14:30:00', hubName: '청주터미널', hubId: '1' },
-          { time: '2024-03-20 14:40:00', hubName: '청주대학교', hubId: '2' },
-          { time: '2024-03-20 14:50:00', hubName: '장소3', hubId: '3' },
-          { time: '2024-03-20 15:00:00', hubName: '장소4', hubId: '4' },
-          { time: '2024-03-20 15:10:00', hubName: '장소5', hubId: '5' },
-          { time: '2024-03-20 15:20:00', hubName: '장소6', hubId: '6' },
-        ]}
+        toDestinationObject={mockData}
+        fromDestinationObject={mockData}
         section={SECTION.MY_RESERVATION}
       />
     </>
@@ -22,3 +16,42 @@ const RouteSection = () => {
 };
 
 export default RouteSection;
+
+const mockData = [
+  {
+    arrivalTime: '2024-03-20 14:30:00',
+    name: '청주터미널',
+    shuttleRouteHubId: 1,
+    sequence: 1,
+  },
+  {
+    arrivalTime: '2024-03-20 14:40:00',
+    name: '청주대학교',
+    shuttleRouteHubId: 2,
+    sequence: 2,
+  },
+  {
+    arrivalTime: '2024-03-20 14:50:00',
+    name: '장소3',
+    shuttleRouteHubId: 3,
+    sequence: 3,
+  },
+  {
+    arrivalTime: '2024-03-20 15:00:00',
+    name: '장소4',
+    shuttleRouteHubId: 4,
+    sequence: 4,
+  },
+  {
+    arrivalTime: '2024-03-20 15:10:00',
+    name: '장소5',
+    shuttleRouteHubId: 5,
+    sequence: 5,
+  },
+  {
+    arrivalTime: '2024-03-20 15:20:00',
+    name: '장소6',
+    shuttleRouteHubId: 6,
+    sequence: 6,
+  },
+] as ShuttleRouteHubObject[];

--- a/src/app/shuttle/[id]/write/page.tsx
+++ b/src/app/shuttle/[id]/write/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SECTION } from '@/types/shuttle.types';
+import { SECTION, ShuttleRouteHubObject } from '@/types/shuttle.types';
 import { FormProvider, useForm } from 'react-hook-form';
 import useFunnel from '@/hooks/useFunnel';
 import NoticeSection, {
@@ -89,7 +89,8 @@ const ShuttleWrite = () => {
                 <>
                   <div id="divider" className="my-16 h-[8px] bg-grey-50" />
                   <ShuttleRouteVisualizer
-                    object={RouteMockData}
+                    toDestinationObject={RouteMockData}
+                    type={'TO_DESTINATION'}
                     section={SECTION.RESERVATION_DETAIL}
                   />
                   <NoticeSection type={NOTICE_TYPE.CANCELLATION_AND_REFUND} />
@@ -166,21 +167,48 @@ const TossPayment = () => {
   return <section className="h-[354px] bg-primary-400">TOSS PAYMENTS</section>;
 };
 
-const RouteMockData = [
-  { time: '2024-03-20 14:30:00', hubName: '청주터미널', hubId: '1' },
+export const RouteMockData: ShuttleRouteHubObject[] = [
   {
-    time: '2024-03-20 14:40:00',
-    hubName: '청주대학교',
-    hubId: '2',
-    isPickup: true,
+    arrivalTime: '2024-03-20 14:30:00',
+    name: '청주터미널',
+    shuttleRouteHubId: 1,
+    sequence: 1,
+    regionId: 1,
   },
-  { time: '2024-03-20 14:50:00', hubName: '장소3', hubId: '3' },
-  { time: '2024-03-20 15:00:00', hubName: '장소4', hubId: '4' },
   {
-    time: '2024-03-20 15:10:00',
-    hubName: '장소5',
-    hubId: '5',
-    isDropoff: true,
+    arrivalTime: '2024-03-20 14:40:00',
+    name: '청주대학교',
+    shuttleRouteHubId: 2,
+    sequence: 2,
+    regionId: 1,
   },
-  { time: '2024-03-20 15:20:00', hubName: '장소6', hubId: '6' },
+  {
+    arrivalTime: '2024-03-20 14:50:00',
+    name: '장소3',
+    shuttleRouteHubId: 3,
+    sequence: 3,
+    regionId: 1,
+    selected: true,
+  },
+  {
+    arrivalTime: '2024-03-20 15:00:00',
+    name: '장소4',
+    shuttleRouteHubId: 4,
+    sequence: 4,
+    regionId: 1,
+  },
+  {
+    arrivalTime: '2024-03-20 15:10:00',
+    name: '장소5',
+    shuttleRouteHubId: 5,
+    sequence: 5,
+    regionId: 1,
+  },
+  {
+    arrivalTime: '2024-03-20 15:20:00',
+    name: '장소6',
+    shuttleRouteHubId: 6,
+    sequence: 6,
+    regionId: 1,
+  },
 ];

--- a/src/components/shuttle-detail/ShuttleDetailPage.tsx
+++ b/src/components/shuttle-detail/ShuttleDetailPage.tsx
@@ -13,6 +13,7 @@ import Spacer from './components/Spacer';
 import { EventDetailProps } from '@/types/event.types';
 import { dateFormatter } from './shuttleDetailPage.utils';
 import { shuttleStateConverter } from './shuttleDetailPage.utils';
+import { RouteMockData } from '@/app/shuttle/[id]/write/page';
 
 interface Props {
   type: 'DEMAND' | 'RESERVATION';
@@ -47,7 +48,8 @@ const ShuttleDetailPage = async ({ type, data }: Props) => {
       {type === 'RESERVATION' && (
         <>
           <ShuttleRouteVisualizer
-            object={ROUTE_OBJECT}
+            toDestinationObject={RouteMockData}
+            type={'TO_DESTINATION'}
             section={SECTION.SHUTTLE_DETAIL}
           />
           <NoticeSection type={NOTICE_TYPE.CANCELLATION_AND_REFUND} />
@@ -61,44 +63,3 @@ const ShuttleDetailPage = async ({ type, data }: Props) => {
 };
 
 export default ShuttleDetailPage;
-
-const ROUTE_OBJECT = [
-  {
-    time: '2024-03-20 14:30:00',
-    location: '청주터미널',
-    hubId: '1',
-    hubName: '청주터미널',
-  },
-  {
-    time: '2024-03-20 14:40:00',
-    location: '청주대학교',
-    hubId: '2',
-    hubName: '청주대학교',
-    is_pickup: true,
-  },
-  {
-    time: '2024-03-20 14:50:00',
-    location: '장소3',
-    hubId: '3',
-    hubName: '장소3',
-  },
-  {
-    time: '2024-03-20 15:00:00',
-    location: '장소4',
-    hubId: '4',
-    hubName: '장소4',
-  },
-  {
-    time: '2024-03-20 15:10:00',
-    location: '장소5',
-    hubId: '5',
-    hubName: '장소5',
-    is_dropoff: true,
-  },
-  {
-    time: '2024-03-20 15:20:00',
-    location: '장소6',
-    hubId: '6',
-    hubName: '장소6',
-  },
-];

--- a/src/components/shuttle/shuttle-route-visualizer/RoutePoint.tsx
+++ b/src/components/shuttle/shuttle-route-visualizer/RoutePoint.tsx
@@ -1,8 +1,8 @@
-import { ROUTE_TYPE, ShuttleRouteObject } from '@/types/shuttle.types';
+import { ROUTE_TYPE, ShuttleRouteHubObject } from '@/types/shuttle.types';
 import { RouteType } from '@/types/shuttle.types';
 
 interface Props {
-  object: ShuttleRouteObject[];
+  object: ShuttleRouteHubObject[];
   type: RouteType;
 }
 

--- a/src/components/shuttle/shuttle-route-visualizer/ShuttleRouteCard.tsx
+++ b/src/components/shuttle/shuttle-route-visualizer/ShuttleRouteCard.tsx
@@ -1,7 +1,7 @@
 import { SECTION } from '@/types/shuttle.types';
 import { RouteType, ROUTE_TYPE } from '@/types/shuttle.types';
 import dayjs from 'dayjs';
-import { ShuttleRouteObject } from '@/types/shuttle.types';
+import { ShuttleRouteHubObject } from '@/types/shuttle.types';
 import { SectionType } from '@/types/shuttle.types';
 import { Control, FieldValues, UseFormSetValue } from 'react-hook-form';
 import { RenderPoints } from './RoutePoint';
@@ -10,7 +10,7 @@ import { isShuttleRouteLocationBlurred } from './shuttleRouteVisualizer.util';
 interface Props {
   section: SectionType;
   type: RouteType;
-  object: ShuttleRouteObject[];
+  object: ShuttleRouteHubObject[];
   control: Control<FieldValues> | null;
   setValue: UseFormSetValue<FieldValues> | null;
 }
@@ -22,10 +22,11 @@ const ShuttleRouteCard = ({
   control,
   setValue,
 }: Props) => {
-  const shuttleTime = dayjs(object[object.length - 1]?.time).diff(
-    dayjs(object[0]?.time),
+  const shuttleTime = dayjs(object[object.length - 1]?.arrivalTime).diff(
+    dayjs(object[0]?.arrivalTime),
     'minutes',
   );
+  const alignedObject = object.sort((a, b) => a.sequence - b.sequence);
 
   return (
     <article
@@ -56,11 +57,11 @@ const ShuttleRouteCard = ({
             className={`absolute h-[calc(100%-12px)] w-[2px] bg-${type === ROUTE_TYPE.DEPARTURE ? 'primary-main' : 'grey-500'} `}
           />
           <ol className="relative flex h-full flex-col items-center justify-between ">
-            <RenderPoints object={object} type={type} />
+            <RenderPoints object={alignedObject} type={type} />
           </ol>
         </div>
         <ul className="flex w-full flex-col gap-16">
-          {object.map((item, index) => (
+          {alignedObject.map((item, index) => (
             <li key={index}>
               <ShuttleRouteTimeLocation
                 type={type}
@@ -92,8 +93,8 @@ const ShuttleRouteCard = ({
       ) : (
         <p className="text-12 font-500 leading-[19.2px] text-grey-500">
           {type === ROUTE_TYPE.DEPARTURE
-            ? object[0]?.hubName
-            : object[object.length - 1]?.hubName}
+            ? alignedObject[0]?.name
+            : alignedObject[alignedObject.length - 1]?.name}
           {type === ROUTE_TYPE.DEPARTURE ? '까지 ' : '부터 '}
           <span className="font-600">약 {shuttleTime}분</span> 소요
         </p>

--- a/src/components/shuttle/shuttle-route-visualizer/ShuttleRouteTimeLocation.tsx
+++ b/src/components/shuttle/shuttle-route-visualizer/ShuttleRouteTimeLocation.tsx
@@ -1,6 +1,6 @@
 import { Controller } from 'react-hook-form';
 import { SECTION } from '@/types/shuttle.types';
-import { RouteType, ShuttleRouteObject } from '@/types/shuttle.types';
+import { RouteType, ShuttleRouteHubObject } from '@/types/shuttle.types';
 import { Control, UseFormSetValue } from 'react-hook-form';
 import { FieldValues } from 'react-hook-form';
 import { SectionType } from '@/types/shuttle.types';
@@ -9,7 +9,7 @@ import dayjs from 'dayjs';
 
 interface Props {
   type: RouteType;
-  object: ShuttleRouteObject;
+  object: ShuttleRouteHubObject;
   isBlurred: boolean;
   section: SectionType;
   control?: Control<FieldValues> | null;
@@ -31,7 +31,7 @@ const ShuttleRouteTimeLocation = ({
     <div className="flex w-full justify-between ">
       <div className="flex items-center gap-16 ">
         <p className="text-12 font-400 leading-[19.2px] text-grey-600-sub">
-          {dayjs(object.time).format('HH:mm')}
+          {dayjs(object.arrivalTime).format('HH:mm')}
         </p>
         <p
           className={`text-16 font-400 leading-[24px] ${
@@ -40,7 +40,7 @@ const ShuttleRouteTimeLocation = ({
               : 'text-grey-900'
           }`}
         >
-          {object.hubName}
+          {object.name}
         </p>
       </div>
       {section === SECTION.RESERVATION_DETAIL && control && setValue && (
@@ -51,9 +51,11 @@ const ShuttleRouteTimeLocation = ({
             <input
               {...field}
               type="radio"
-              id={`${type}-${fieldName}-${object.hubId}`}
-              value={`${object.hubId}`}
-              checked={field.value === `${object.hubId}`}
+              id={`${type}-${fieldName}-${object.shuttleRouteHubId}`}
+              value={`${object.shuttleRouteHubId}`}
+              checked={
+                String(field.value) === String(`${object.shuttleRouteHubId}`)
+              }
               onChange={(e) => {
                 field.onChange(e);
                 setValue(fieldName, e.target.value);

--- a/src/components/shuttle/shuttle-route-visualizer/ShuttleRouteVisualizer.stories.tsx
+++ b/src/components/shuttle/shuttle-route-visualizer/ShuttleRouteVisualizer.stories.tsx
@@ -3,6 +3,7 @@ import ShuttleRouteVisualizer from './ShuttleRouteVisualizer';
 import { SECTION } from '@/types/shuttle.types';
 import { useForm } from 'react-hook-form';
 import { FormProvider } from 'react-hook-form';
+import { RouteMockData } from '@/app/shuttle/[id]/write/page';
 
 const ShuttleRouteVisualizerWrapper = (
   props: any, // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -27,62 +28,27 @@ type Story = StoryObj<typeof ShuttleRouteVisualizer>;
 
 export const ShuttleDetail: Story = {
   args: {
-    object: [
-      { time: '2024-03-20 14:30:00', hubName: '청주터미널', hubId: '1' },
-      { time: '2024-03-20 14:40:00', hubName: '청주대학교', hubId: '2' },
-      { time: '2024-03-20 14:50:00', hubName: '장소3', hubId: '3' },
-      { time: '2024-03-20 15:00:00', hubName: '장소4', hubId: '4' },
-      { time: '2024-03-20 15:10:00', hubName: '장소5', hubId: '5' },
-      { time: '2024-03-20 15:20:00', hubName: '장소6', hubId: '6' },
-    ],
+    toDestinationObject: RouteMockData,
+    fromDestinationObject: RouteMockData,
+    type: 'ROUND_TRIP',
     section: SECTION.SHUTTLE_DETAIL,
   },
 };
 
 export const ReservationDetail: Story = {
   args: {
-    object: [
-      { time: '2024-03-20 14:30:00', hubName: '청주터미널', hubId: '1' },
-      {
-        time: '2024-03-20 14:40:00',
-        hubName: '청주대학교',
-        hubId: '2',
-        isPickup: true,
-      },
-      { time: '2024-03-20 14:50:00', hubName: '장소3', hubId: '3' },
-      { time: '2024-03-20 15:00:00', hubName: '장소4', hubId: '4' },
-      { time: '2024-03-20 15:10:00', hubName: '장소5', hubId: '5' },
-      {
-        time: '2024-03-20 15:20:00',
-        hubName: '장소6',
-        hubId: '6',
-        isDropoff: true,
-      },
-    ],
+    toDestinationObject: RouteMockData,
+    fromDestinationObject: RouteMockData,
+    type: 'ROUND_TRIP',
     section: SECTION.RESERVATION_DETAIL,
   },
 };
 
 export const MyReservation: Story = {
   args: {
-    object: [
-      { time: '2024-03-20 14:30:00', hubName: '청주터미널', hubId: '1' },
-      {
-        time: '2024-03-20 14:40:00',
-        hubName: '청주대학교',
-        hubId: '2',
-        isPickup: true,
-      },
-      { time: '2024-03-20 14:50:00', hubName: '장소3', hubId: '3' },
-      { time: '2024-03-20 15:00:00', hubName: '장소4', hubId: '4' },
-      { time: '2024-03-20 15:10:00', hubName: '장소5', hubId: '5' },
-      {
-        time: '2024-03-20 15:20:00',
-        hubName: '장소6',
-        hubId: '6',
-        isDropoff: true,
-      },
-    ],
+    toDestinationObject: RouteMockData,
+    fromDestinationObject: RouteMockData,
+    type: 'ROUND_TRIP',
     section: SECTION.MY_RESERVATION,
   },
 };

--- a/src/components/shuttle/shuttle-route-visualizer/shuttleRouteVisualizer.util.ts
+++ b/src/components/shuttle/shuttle-route-visualizer/shuttleRouteVisualizer.util.ts
@@ -1,4 +1,4 @@
-import { ROUTE_TYPE, ShuttleRouteObject } from '@/types/shuttle.types';
+import { ROUTE_TYPE, ShuttleRouteHubObject } from '@/types/shuttle.types';
 import { RouteType } from '@/types/shuttle.types';
 
 export const isShuttleRouteLocationBlurred = ({
@@ -7,13 +7,13 @@ export const isShuttleRouteLocationBlurred = ({
   index,
   length,
 }: {
-  object: ShuttleRouteObject;
+  object: ShuttleRouteHubObject;
   type: RouteType;
   index: number;
   length: number;
 }) => {
   if (type === ROUTE_TYPE.DEPARTURE)
-    return !(index === length - 1 || object.isPickup);
-  if (type === ROUTE_TYPE.RETURN) return !(index === 0 || object.isDropoff);
+    return !(index === length - 1 || object.selected);
+  if (type === ROUTE_TYPE.RETURN) return !(index === 0 || object.selected);
   return false;
 };

--- a/src/types/shuttle.types.ts
+++ b/src/types/shuttle.types.ts
@@ -5,14 +5,6 @@ export const ROUTE_TYPE = {
 
 export type RouteType = (typeof ROUTE_TYPE)[keyof typeof ROUTE_TYPE];
 
-export type ShuttleRouteObject = {
-  time: string;
-  hubId: string;
-  hubName: string;
-  isPickup?: boolean;
-  isDropoff?: boolean;
-};
-
 export const SECTION = {
   SHUTTLE_DETAIL: 'SHUTTLE-DETAIL',
   RESERVATION_DETAIL: 'RESERVATION-DETAIL',
@@ -42,19 +34,9 @@ export interface ShuttleRoute {
 }
 
 export interface Hub {
-  pickup: {
-    name: string;
-    sequence: number;
-    regionId: number;
-    arrivalTime: string;
-  }[];
+  pickup: ShuttleRouteHubObject[];
 
-  dropoff: {
-    name: string;
-    sequence: number;
-    regionId: number;
-    arrivalTime: string;
-  }[];
+  dropoff: ShuttleRouteHubObject[];
 
   destination: {
     name: string;
@@ -63,6 +45,15 @@ export interface Hub {
     arrivalTime: string;
   };
 }
+
+export type ShuttleRouteHubObject = {
+  shuttleRouteHubId: number;
+  name: string;
+  sequence: number;
+  regionId: number;
+  arrivalTime: string;
+  selected?: boolean;
+};
 
 export interface ShuttleRouteEvent {
   name: string;


### PR DESCRIPTION
## 업데이트 내역

type prop으로 `왕복행` / `콘서트행` / `귀가행` 노선을 보여줄 수 있습니다.
기존의 object prop대신 `toDestinationObject`, `fromDestinationObject` 를 사용합니다.
`{ arrivalTime, name, shuttleRouteHubId, sequence, selected? }[]` 형태로 넘겨주세요.
Section === MY_RESERVATION 일때 `selected` 된 승탑지는 기본값으로 선택되어있습니다


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).