### PR TITLE
fix: 바텀시트 높이에 따라서 transform duration 분리

### DIFF
--- a/src/hooks/useBottomSheet.tsx
+++ b/src/hooks/useBottomSheet.tsx
@@ -1,13 +1,15 @@
 import { MutableRefObject, useCallback, useRef } from 'react';
 
 interface Metrics {
+  transformDuration: string;
   initTouchPosition: number | null;
   initTransformValue: number;
   isContentAreaTouched: boolean;
   closingY: number;
 }
 
-const TRANSFORM_DURATION = '200ms';
+const TRANSFORM_DURATION = { short: '200ms', long: '290ms' };
+const LONG_BOTTOM_SHEET_HEIGHT = 500;
 
 const useBottomSheet = () => {
   const bottomSheetRef = useCallback((bottomSheetElement: HTMLDivElement) => {
@@ -74,6 +76,7 @@ const useBottomSheet = () => {
   const backdrop: MutableRefObject<HTMLElement | null> = useRef(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const metrics = useRef<Metrics>({
+    transformDuration: TRANSFORM_DURATION.short,
     initTouchPosition: null,
     initTransformValue: 0,
     isContentAreaTouched: false,
@@ -92,13 +95,20 @@ const useBottomSheet = () => {
     backdropElement.style.display = 'flex';
 
     const bottomSheetHeight = bottomSheetElement.clientHeight;
+    if (bottomSheetHeight > LONG_BOTTOM_SHEET_HEIGHT) {
+      metrics.current.transformDuration = TRANSFORM_DURATION.long;
+    } else {
+      metrics.current.transformDuration = TRANSFORM_DURATION.short;
+    }
+
     bottomSheetElement.style.transform = `translateY(${bottomSheetHeight}px)`;
     metrics.current.closingY = bottomSheetHeight / 2;
 
     setTimeout(() => {
-      bottomSheetElement.style.transitionDuration = TRANSFORM_DURATION;
+      bottomSheetElement.style.transitionDuration =
+        metrics.current.transformDuration;
       bottomSheetElement.style.transform = `translateY(0px)`;
-    }, 10);
+    }, 0);
   };
 
   const closeBottomSheet = () => {
@@ -108,13 +118,14 @@ const useBottomSheet = () => {
       return;
     }
     const bottomSheetHeight = bottomSheetElement.clientHeight;
-    bottomSheetElement.style.transitionDuration = TRANSFORM_DURATION;
+    bottomSheetElement.style.transitionDuration =
+      metrics.current.transformDuration;
     bottomSheetElement.style.transform = `translateY(${bottomSheetHeight}px)`;
 
     setTimeout(() => {
       bottomSheetElement.style.display = 'none';
       backdropElement.style.display = 'none';
-    }, 150);
+    }, 130);
   };
 
   // 바텀시트 드래그
@@ -164,7 +175,8 @@ const useBottomSheet = () => {
         .replace('translateY(', '')
         .replace('px)', '') || 0,
     );
-    bottomSheetElement.style.transitionDuration = TRANSFORM_DURATION;
+    bottomSheetElement.style.transitionDuration =
+      metrics.current.transformDuration;
 
     if (finalTransformValue < closingY) {
       bottomSheetElement.style.transform = `translateY(0px)`;


### PR DESCRIPTION
## 개요

바텀시트의 높이가 클 시 바텀시트가 올라오는 속도가 너무 빠른 문제를 해결하기 위해 높이별로 transform duration을 달리 했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).