### PR TITLE
fix: 쿠폰 체크박스가 안눌리는 문제 해결

### DIFF
--- a/src/app/mypage/coupons/components/CouponList.tsx
+++ b/src/app/mypage/coupons/components/CouponList.tsx
@@ -58,7 +58,10 @@ const CouponList = ({ coupons }: Props) => {
           onClick={() => setShowUnusableCoupons((prev) => !prev)}
           className="flex items-center gap-4 text-12"
         >
-          <CheckBox isChecked={showUnusableCoupons} />
+          <CheckBox
+            isChecked={showUnusableCoupons}
+            setIsChecked={setShowUnusableCoupons}
+          />
           사용 불가능한 쿠폰 포함
         </button>
       </div>


### PR DESCRIPTION
## 개요

마이 페이지 쿠폰 필터에서 체크박스 부분이 안눌리는 문제를 해결했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).