### PR TITLE
fix: 바텀시트 열렸을 시 배경 스크롤 방지

### DIFF
--- a/src/components/bottom-sheet/BottomSheet.tsx
+++ b/src/components/bottom-sheet/BottomSheet.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ReactNode, forwardRef } from 'react';
 import BottomSheetPortal from './BottomSheetPortal';
 

--- a/src/hooks/useBottomSheet.tsx
+++ b/src/hooks/useBottomSheet.tsx
@@ -1,4 +1,5 @@
 import { MutableRefObject, useCallback, useRef } from 'react';
+import usePreventScroll from './usePreventScroll';
 
 interface Metrics {
   transformDuration: string;
@@ -12,6 +13,8 @@ const TRANSFORM_DURATION = { short: '200ms', long: '290ms' };
 const LONG_BOTTOM_SHEET_HEIGHT = 500;
 
 const useBottomSheet = () => {
+  const { preventScroll, allowScroll } = usePreventScroll();
+
   const bottomSheetRef = useCallback((bottomSheetElement: HTMLDivElement) => {
     if (!bottomSheetElement || !bottomSheetElement?.parentElement) {
       return;
@@ -85,6 +88,7 @@ const useBottomSheet = () => {
 
   // 바텀시트 열고 닫기
   const openBottomSheet = () => {
+    preventScroll();
     const bottomSheetElement = bottomSheet.current;
     const backdropElement = backdrop.current;
     if (!bottomSheetElement || !backdropElement) {
@@ -112,6 +116,7 @@ const useBottomSheet = () => {
   };
 
   const closeBottomSheet = () => {
+    allowScroll();
     const bottomSheetElement = bottomSheet.current;
     const backdropElement = backdrop.current;
     if (!bottomSheetElement || !backdropElement) {

--- a/src/hooks/usePreventScroll.ts
+++ b/src/hooks/usePreventScroll.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+
+const usePreventScroll = () => {
+  const preventScroll = useCallback(() => {
+    document.body.style.overflow = 'hidden';
+  }, []);
+
+  const allowScroll = useCallback(() => {
+    document.body.style.overflow = 'unset';
+  }, []);
+
+  return { preventScroll, allowScroll };
+};
+
+export default usePreventScroll;


### PR DESCRIPTION
## 개요

기존에 바텀시트가 열렸을 때 뒷 배경이 스크롤 되던 문제를 해결했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).