### PR TITLE
fix(예약하기): 예약하기에서 가격 포맷팅

### DIFF
--- a/src/app/shuttle/[id]/write/sections/PriceDetail.tsx
+++ b/src/app/shuttle/[id]/write/sections/PriceDetail.tsx
@@ -38,7 +38,7 @@ const PriceDetail = ({ SelectedCoupon, shuttleData }: props) => {
               passengerCount,
               currentShuttleData,
               tripType,
-            })}
+            })?.toLocaleString()}
             원
           </dd>
           <dd className="text-12 font-400 leading-[19.2px] text-grey-900">
@@ -47,7 +47,7 @@ const PriceDetail = ({ SelectedCoupon, shuttleData }: props) => {
               passengerCount: 1,
               currentShuttleData,
               tripType,
-            })}
+            })?.toLocaleString()}
             원 * {passengerCount}인)
           </dd>
         </div>
@@ -69,7 +69,7 @@ const PriceDetail = ({ SelectedCoupon, shuttleData }: props) => {
                 currentShuttleData,
                 passengerCount,
                 tripType,
-              })}
+              })?.toLocaleString()}
               원
             </dd>
             {isDiscounted && (
@@ -90,7 +90,7 @@ const PriceDetail = ({ SelectedCoupon, shuttleData }: props) => {
             currentShuttleData,
             passengerCount,
             tripType,
-          })}
+          })?.toLocaleString()}
           원
         </dd>
       </div>

--- a/src/components/shuttle-detail/bottom-bar/BottomBarReservationRequest.tsx
+++ b/src/components/shuttle-detail/bottom-bar/BottomBarReservationRequest.tsx
@@ -91,7 +91,7 @@ const BottomBarReservationRequest = ({
                 tripType,
                 passengerCount,
                 selectedCoupon,
-              })}
+              })?.toLocaleString()}
               원 결제하기
             </Button>
           </div>

--- a/src/components/shuttle-detail/bottom-bar/PriceInfo.tsx
+++ b/src/components/shuttle-detail/bottom-bar/PriceInfo.tsx
@@ -15,15 +15,21 @@ const PriceInfo = ({ currentShuttleData, passengerCount, tripType }: Props) => {
       </span>
       <div className="flex items-center text-12 font-400 leading-[19.2px] text-grey-600-sub ">
         <span>
+          (
           {totalPrice({
             currentShuttleData,
             tripType,
             passengerCount: 1,
-          })}
-          * {passengerCount}인
+          })?.toLocaleString()}{' '}
+          원 * {passengerCount}인)
         </span>
         <span className="ml-12 text-22 font-700 leading-[35.2px] text-grey-900">
-          총 {totalPrice({ currentShuttleData, tripType, passengerCount })}
+          총{' '}
+          {totalPrice({
+            currentShuttleData,
+            tripType,
+            passengerCount,
+          })?.toLocaleString()}
         </span>
         <span className="ml-4 text-14 font-400 leading-[22.4px] text-grey-900">
           원


### PR DESCRIPTION
## 개요
예약하기 전 과정에서 가격에 쉼표로 3글자씩 구분지어지는 포맷팅을 적용했습니다.
<img width="275" alt="Screenshot 2025-01-06 at 3 20 55 PM" src="https://github.com/user-attachments/assets/7261dbf2-3bc9-4ede-9254-ddc34115e6b1" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).