### PR TITLE
fix(예약하기): 쿠폰 최대 적용인원이슈, 명당 가격표기 이슈 해결

### DIFF
--- a/src/app/shuttle/[id]/write/sections/PriceDetail.tsx
+++ b/src/app/shuttle/[id]/write/sections/PriceDetail.tsx
@@ -1,12 +1,7 @@
 import { IssuedCouponType } from '@/types/client.types';
 import { ShuttleRoute } from '@/types/shuttle.types';
 import { useFormContext } from 'react-hook-form';
-import {
-  discountAmount,
-  finalPrice,
-  totalPrice,
-  totalRegularPrice,
-} from './priceDetail.util';
+import { discountAmount, finalPrice, totalPrice } from './priceDetail.util';
 
 interface props {
   SelectedCoupon: IssuedCouponType;
@@ -43,7 +38,7 @@ const PriceDetail = ({ SelectedCoupon, shuttleData }: props) => {
           </dd>
           <dd className="text-12 font-400 leading-[19.2px] text-grey-900">
             (
-            {totalRegularPrice({
+            {totalPrice({
               passengerCount: 1,
               currentShuttleData,
               tripType,

--- a/src/app/shuttle/[id]/write/sections/TotalPriceInfo.tsx
+++ b/src/app/shuttle/[id]/write/sections/TotalPriceInfo.tsx
@@ -181,7 +181,7 @@ const Coupon = ({
       </div>
       <div>
         <p className="text-12 font-400 leading-[19.2px] text-grey-500">
-          예약 당 최대 1인 적용
+          예약 당 최대 {coupon.maxApplicablePeople}인 적용
         </p>
         <p className="text-12 font-400 leading-[19.2px] text-grey-500">
           {coupon.validTo}까지 사용 가능
@@ -207,7 +207,7 @@ const SelectedCoupon = ({ coupon }: { coupon: IssuedCouponType }) => {
       </div>
       <div>
         <p className="text-12 font-400 leading-[19.2px] text-grey-500">
-          예약 당 최대 1인 적용
+          예약 당 최대 {coupon.maxApplicablePeople}인 적용
         </p>
         <p className="text-12 font-400 leading-[19.2px] text-grey-500">
           {coupon.validTo}까지 사용 가능


### PR DESCRIPTION
## 개요
- 쿠폰의 최대 적용인원이 1명으로 고정돼 잘못표기된 이슈 해결
- 예약하기 명당 가격이 얼리버드 일경우에도 일반 가격으로 표기되던 이슈 해결


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).