### PR TITLE
fix: 토스페이먼츠 중 강제중단, 쿠폰 선택시 스크롤이 안되는 이슈

### DIFF
--- a/src/app/shuttle/[id]/write/page.tsx
+++ b/src/app/shuttle/[id]/write/page.tsx
@@ -157,7 +157,7 @@ const ShuttleWrite = ({ params }: Props) => {
 
   if (!data || !dailyShuttleArray || !dailyShuttleRouteArray) return;
   return (
-    <main>
+    <main className="h-screen overflow-y-auto [&::-webkit-scrollbar]:hidden">
       <FormProvider {...methods}>
         <Funnel>
           <Step name={1}>


### PR DESCRIPTION
## 개요
- 쿠폰등록시, 결제 취소 시 Toss Payments SDK UI 가 재렌더링되면서 발생하는 이슈입니다. toss payments sdk가 직접 dom 을 조작하면서 발생하는 이슈로 예상됩니다. 화면의 크기를 직접 지정하고 scoll-y 를 지정하는 방식으로 해결하였습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).