### PR TITLE
fix(카카오맵): 지도 UI 렌더링 이슈 해결, 카카오맵 키 핸디버스 앱 키로 변경

### DIFF
--- a/src/components/shuttle-detail/components/KakaoMap.tsx
+++ b/src/components/shuttle-detail/components/KakaoMap.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { RefObject, useRef, useState } from 'react';
+import { RefObject, useEffect, useRef, useState } from 'react';
 import Script from 'next/script';
 import LogoIcon from 'public/icons/logo-small.svg';
 import KakaoMapIcon from 'public/icons/kakaomap-logo.svg';
@@ -90,6 +90,14 @@ const KakaoMapContent = ({
   initializeMap,
   mapRef,
 }: KakaoMapContentProps) => {
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (loaded) {
+      window.kakao.maps.load(initializeMap);
+    }
+  }, [loaded]);
+
   return (
     <article
       className="relative h-auto p-16 [&_div]:cursor-pointer"
@@ -103,7 +111,7 @@ const KakaoMapContent = ({
         id="kakao-maps-sdk"
         strategy="afterInteractive"
         src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_APP_KEY}&autoload=false&libraries=services`}
-        onLoad={() => window.kakao.maps.load(initializeMap)}
+        onReady={() => setLoaded(true)}
       />
       <div className="absolute right-16 top-[-8px] flex items-center justify-end ">
         <KakaoMapIcon viewBox="0 0 12 13" width="12px" height="12px" />

--- a/src/components/shuttle-detail/components/KakaoMap.tsx
+++ b/src/components/shuttle-detail/components/KakaoMap.tsx
@@ -110,7 +110,7 @@ const KakaoMapContent = ({
       <Script
         id="kakao-maps-sdk"
         strategy="afterInteractive"
-        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_APP_KEY}&autoload=false&libraries=services`}
+        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY}&autoload=false&libraries=services`}
         onReady={() => setLoaded(true)}
       />
       <div className="absolute right-16 top-[-8px] flex items-center justify-end ">


### PR DESCRIPTION
## 개요
지도 UI 렌더링 이슈 해결
- [문제원인] script로 제공되는 kakao map sdk를 사용하기 위해서 Next/Script를 사용하고 있습니다. `onLoad` 메서드를 사용하고있었는데, 이는 Script가 로드될때 onLoad 메서드로 제공되는 걸 함께 실행합니다. 이때문에 Script가 먼저 로드될 때 `window.kakao.maps` 가 준비되지 않았을 수 있습니다. 타이밍이 맞지 않으면 카카오맵 UI가 로드 되지 않는것이죠.
- [해결방법] `onReady` 메서드를 사용해서, 카카오맵 SDK가 완전히 준비되었을때 로드합니다.

카카오맵 키 환경변수 관련
- 기존의 사용하던 `NEXT_PUBLIC_KAKAO_MAP_APP_KEY`는 더이상 필요하지 않습니다. 각자 로컬에서 지워주셔도 됩니다. 기존 `NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY`를 함께 사용합니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).