### PR TITLE
test(카카오맵): 카카오맵 env key를 handybus 계정의 env key로 변경

### DIFF
--- a/src/components/kakao-map/KakaoMap.tsx
+++ b/src/components/kakao-map/KakaoMap.tsx
@@ -110,7 +110,7 @@ const KakaoMapContent = ({
       <Script
         id="kakao-maps-sdk"
         strategy="afterInteractive"
-        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_APP_KEY}&autoload=false&libraries=services`}
+        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY}&autoload=false&libraries=services`}
         onReady={() => setLoaded(true)}
       />
       <div className="absolute right-16 top-[-8px] flex items-center justify-end ">


### PR DESCRIPTION
## 개요
vercel env가 제대로 적용되지 않는 이슈로 인해서 테스트를 진행합니다.
NEXT_PUBLIC_KAKAO_MAP_APP_KEY(제 계정의 임시 키) -> NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY(핸디버스 계정의 공식키) 로 변경합니다
둘 다 모두 kakao develop API 키에서 javascript 키 입니다. 

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).