### PR TITLE
feat(SEO): robots, viewport, sitemap 설정 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,15 +33,14 @@ export const metadata: Metadata = {
       },
     ],
   },
-  twitter: {
-    card: 'summary_large_image',
-    title: TITLE,
-    description: DESCRIPTION,
-    images: [OG_IMAGE_URL],
-  },
   robots: {
     index: true,
     follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+    },
   },
   verification: {
     google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -3,7 +3,7 @@ import { MetadataRoute } from 'next';
 export default function robots(): MetadataRoute.Robots {
   const baseUrl = 'https://www.handybus.co.kr';
 
-  if (process.env.NEXT_PUBLIC_ENV !== 'production') {
+  if (process.env.NODE_ENV !== 'production') {
     return {
       rules: {
         userAgent: '*',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,22 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = 'https://www.handybus.co.kr';
+
+  if (process.env.NEXT_PUBLIC_ENV !== 'production') {
+    return {
+      rules: {
+        userAgent: '*',
+        disallow: '*',
+      },
+    };
+  }
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/mypage', '/mypage/*'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -82,7 +82,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.8,
   }));
   const shuttleRoutesArray = shuttleRoutes.map((route) => ({
-    url: `${baseUrl}/shuttle-route/${route.shuttleRouteId}`,
+    url: `${baseUrl}/reservation/${route.shuttleRouteId}`,
     lastModified: new Date(),
     changeFrequency: 'daily' as ChangeFreq,
     priority: 0.8,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,93 @@
+import { MetadataRoute } from 'next';
+import {
+  getEvents,
+  getShuttleRoutes,
+} from '@/services/shuttle-operation.service';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = 'https://www.handybus.co.kr';
+  type ChangeFreq =
+    | 'always'
+    | 'hourly'
+    | 'daily'
+    | 'weekly'
+    | 'monthly'
+    | 'yearly'
+    | 'never';
+
+  /*
+   * priority: 0 ~ 1 사이의 값으로 설정해주세요. 검색엔진의 크롤링 빈도에 영향을 줍니다.
+   * lastModified는 페이지의 마지막 수정된 날짜를 나타냅니다.
+   * changeFrequency는 페이지가 얼마나 자주 변경될 것으로 예상되는지 검색엔진에 알려주는 지표입니다. 실제로 페이지의 내용이 변경되지 않았는데 빈도를 높게 설정하면 검색엔진이 신뢰도를 낮게 평가할 수 있습니다.
+   * priority, changeFrequency는 google에서 절대적으로 반영하지않고 참고만 하는것으로 알려져있습니다.
+   * help 섹션과 같은 경우는 페이지의 내용이 바뀌지 않기 때문에 날짜를 고정해 두었습니다. 이후 내용이 바뀌면 날짜를 업데이트 해주세요.
+   */
+  const staticRoutes = [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      priority: 1.0,
+    },
+    {
+      url: `${baseUrl}/demand`,
+      lastModified: new Date(),
+      changeFrequency: 'daily' as ChangeFreq,
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/reservation`,
+      lastModified: new Date(),
+      changeFrequency: 'daily' as ChangeFreq,
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/help/reviews`,
+      lastModified: new Date(),
+      changeFrequency: 'daily' as ChangeFreq,
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/help/about`,
+      lastModified: new Date('2025-01-15'),
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/help/how-to`,
+      lastModified: new Date('2025-01-15'),
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/help/what-is-handy`,
+      lastModified: new Date('2025-01-15'),
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/help/faq`,
+      lastModified: new Date('2025-01-15'),
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/policy`,
+      lastModified: new Date('2025-01-15'),
+      priority: 0.5,
+    },
+  ];
+
+  const events = await getEvents();
+  const shuttleRoutes = await getShuttleRoutes();
+  const eventsArray = events.map((event) => ({
+    url: `${baseUrl}/demand/${event.eventId}`,
+    lastModified: new Date(),
+    changeFrequency: 'daily' as ChangeFreq,
+    priority: 0.8,
+  }));
+  const shuttleRoutesArray = shuttleRoutes.map((route) => ({
+    url: `${baseUrl}/shuttle-route/${route.shuttleRouteId}`,
+    lastModified: new Date(),
+    changeFrequency: 'daily' as ChangeFreq,
+    priority: 0.8,
+  }));
+  const dynamicRoutes = [...eventsArray, ...shuttleRoutesArray];
+
+  return [...staticRoutes, ...dynamicRoutes];
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -77,14 +77,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const shuttleRoutes = await getShuttleRoutes();
   const eventsArray = events.map((event) => ({
     url: `${baseUrl}/demand/${event.eventId}`,
-    lastModified: new Date(),
-    changeFrequency: 'daily' as ChangeFreq,
+    lastModified: new Date(event.updatedAt),
+    // changeFrequency: 'weekly' as ChangeFreq,
     priority: 0.8,
   }));
   const shuttleRoutesArray = shuttleRoutes.map((route) => ({
-    url: `${baseUrl}/reservation/${route.shuttleRouteId}`,
-    lastModified: new Date(),
-    changeFrequency: 'daily' as ChangeFreq,
+    url: `${baseUrl}/reservation/${route.eventId}?dailyShuttleId=${route.dailyEventId}&shuttleRouteId=${route.shuttleRouteId}`,
+    lastModified: new Date(route.updatedAt),
+    // changeFrequency: 'weekly' as ChangeFreq,
     priority: 0.8,
   }));
   const dynamicRoutes = [...eventsArray, ...shuttleRoutesArray];

--- a/src/constants/metadata.ts
+++ b/src/constants/metadata.ts
@@ -37,10 +37,5 @@ export const createMetadataWithOG = (
         'max-image-preview': 'large',
       },
     },
-    viewport: {
-      width: 'device-width',
-      initialScale: 1,
-      maximumScale: 1,
-    },
   };
 };

--- a/src/constants/metadata.ts
+++ b/src/constants/metadata.ts
@@ -28,10 +28,19 @@ export const createMetadataWithOG = (
         },
       ],
     },
-    twitter: {
-      title,
-      description,
-      images: [image],
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        'max-image-preview': 'large',
+      },
+    },
+    viewport: {
+      width: 'device-width',
+      initialScale: 1,
+      maximumScale: 1,
     },
   };
 };

--- a/src/types/shuttle-operation.type.ts
+++ b/src/types/shuttle-operation.type.ts
@@ -79,6 +79,8 @@ export const EventSchema = z
     eventLocationLongitude: z.number(),
     eventArtists: ArtistSchema.array().nullable(),
     dailyEvents: DailyEventSchema.array(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
   })
   .strict();
 export type Event = z.infer<typeof EventSchema>;
@@ -123,6 +125,8 @@ export const ShuttleRouteSchema = z
     toDestinationShuttleRouteHubs: ShuttleRouteHubSchema.array().nullable(),
     fromDestinationShuttleRouteHubs: ShuttleRouteHubSchema.array().nullable(),
     event: EventSchema,
+    createdAt: z.string(),
+    updatedAt: z.string(),
   })
   .strict();
 export type ShuttleRoute = z.infer<typeof ShuttleRouteSchema>;


### PR DESCRIPTION
## 개요
metadata에 robots, viewport 를 추가하고, 기존의 twitter 프로퍼티를 제거하였습니다.
- twitter 프로퍼티가 없을때 twitter(x)는 openGraph 기존에 작성되었던 title, description, image 의 메타데이터를 가져옵니다. 
- viewport 는 모바일에서 검색엔진최적화와 관련되어있습니다 (아래 참고)
- robots 의 설정을 추가하였습니다.

ENV `production` 여부에 따라 sitemap 이 생성/비생성이 결정됩니다. dev domain의 경우 sitemap 이 등록되지 않기 위함.

sitemap 설정에서 `lastModified` 는 변경된 컨텐츠 내용을 반영해줘야합니다. 가장 좋은건 `event`, `shuttleRoute`가 생성 및 수정된 날짜를 동적으로 넣어주는 것입니다. 현재 api 스키마상에 관련 내용을 간단하게 가져올 수가 없어서 서버가 생성된 날짜로 들어가게 됩니다.

`/reservation/{shuttleRouteId}` 경로의 경우에는 현재 쿼리파람이 없을땐 페이지에러가 발생합니다. 이렇게 되면 크롤러가 올바르게 반영하지 못할 수 있습니다. 쿼리를 반영하자니, 서버사이드로 그려주는 페이지가 각각 다른 쿼리파람일때도 똑같은 내용의 컨텐츠만 그려줄것으로 예상되기에 오히려 검색엔진의 신뢰도 하락을 부를 수 있습니다. 

`domain-url/sitemap.xml` 로 접근하시면 생성된 라우팅경로를 모두 확인하실 수 있어요
다른 서비스들을 예로들어 보여드리자면 `https://www.lawtalk.co.kr/sitemap.xml` 와 같은 사례가 있는데요. 이처럼 기존 서비스들의 sitemap에 접근하실 수 있습니다. 

#### 참고
Viewport 설정이 없을 때 발생하는 문제:
- 모바일에서 데스크톱 버전으로 표시될 수 있음
- 자동 확대/축소로 인한 레이아웃 깨짐
- 모바일 SEO 점수 하락

Robots
- index : 인덱싱 여부
- follow: 링크 탐색 여부
- google max-image-preivew : 구글 이미지 검색 반영 여부

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).