### PR TITLE
fix: 로그인 여부에 따라 로그인 버튼 다르게 표시 및 공유하기 버튼 디자인 수정

### DIFF
--- a/src/app/demand/[id]/components/BottomBar.tsx
+++ b/src/app/demand/[id]/components/BottomBar.tsx
@@ -2,8 +2,6 @@
 
 import useBottomSheet from '@/hooks/useBottomSheet';
 import Button from '@/components/buttons/button/Button';
-import IconButton from '@/components/buttons/icon-button/IconButton';
-import ShareIcon from 'public/icons/share.svg';
 import ShareSheet from '@/components/bottom-sheet/share-sheet/ShareSheet';
 
 interface Props {
@@ -24,15 +22,13 @@ const BottomBar = ({ eventName, disabled = false }: Props) => {
             결과를 노선 개설에 활용합니다.
           </p>
 
-          <div className=" flex justify-between gap-12">
-            <Button disabled={disabled}>수요 신청하기</Button>
-            <IconButton
-              type="button"
-              className="h-44 w-44"
-              onClick={openBottomSheet}
-            >
-              <ShareIcon />
-            </IconButton>
+          <div className="flex justify-between gap-12 font-600">
+            <Button type="button" disabled={disabled}>
+              수요 신청하기
+            </Button>
+            <Button type="button" variant="secondary" onClick={openBottomSheet}>
+              친구에게 알리기
+            </Button>
           </div>
         </div>
       </div>

--- a/src/app/reservation/[id]/components/BottomBar.tsx
+++ b/src/app/reservation/[id]/components/BottomBar.tsx
@@ -2,8 +2,6 @@
 
 import useBottomSheet from '@/hooks/useBottomSheet';
 import Button from '@/components/buttons/button/Button';
-import IconButton from '@/components/buttons/icon-button/IconButton';
-import ShareIcon from 'public/icons/share.svg';
 import ShareSheet from '@/components/bottom-sheet/share-sheet/ShareSheet';
 
 interface Props {
@@ -19,15 +17,11 @@ const BottomBar = ({ disabled = false, eventName }: Props) => {
     <>
       <div className="fixed bottom-0 left-0 right-0 mx-auto max-w-500 bg-white shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]">
         <div className="flex flex-col gap-4 px-16 py-8">
-          <div className=" flex justify-between gap-12">
+          <div className="flex justify-between gap-12 font-600">
             <Button disabled={disabled}>셔틀 예약하러 가기</Button>
-            <IconButton
-              type="button"
-              className="h-44 w-44"
-              onClick={openBottomSheet}
-            >
-              <ShareIcon />
-            </IconButton>
+            <Button type="button" variant="secondary" onClick={openBottomSheet}>
+              친구에게 알리기
+            </Button>
           </div>
         </div>
       </div>

--- a/src/app/reservation/components/ShuttleRouteView.tsx
+++ b/src/app/reservation/components/ShuttleRouteView.tsx
@@ -33,7 +33,7 @@ const ShuttleRouteView = ({ shuttleRoute }: Props) => {
       </div>
       <div className="flex h-[110px] flex-col gap-4 overflow-hidden">
         <div className="line-clamp-1 text-16 font-500 text-grey-900">
-          {shuttleRoute.event.eventName}
+          [{shuttleRoute.name}] {shuttleRoute.event.eventName}
         </div>
         <div className="text-12 font-400">
           <div className="line-clamp-1 text-grey-900">
@@ -42,7 +42,6 @@ const ShuttleRouteView = ({ shuttleRoute }: Props) => {
           <div className="line-clamp-1 text-grey-900">
             {dateString(dailyEvent.date)} 셔틀
           </div>
-          <div className="line-clamp-1 text-grey-500">{shuttleRoute.name}</div>
         </div>
         <div className="line-clamp-1 text-14 font-500 text-grey-900">
           <SeatString shuttleRoute={shuttleRoute} />

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,19 +1,29 @@
-'use client';
-
 import UserIcon from 'public/icons/user.svg';
 import LogoIcon from 'public/icons/logo.svg';
 import Link from 'next/link';
+import { getRefreshToken } from '@/utils/handleToken.util';
 
-const Header = () => {
+const Header = async () => {
+  const isLoggedIn = Boolean(await getRefreshToken());
+
   return (
     <header className="sticky top-0 z-50 flex h-48 w-full items-center justify-between bg-white px-16 py-12">
       <h1 className="sr-only">핸디버스</h1>
       <Link href="/">
         <LogoIcon fill="black" />
       </Link>
-      <Link href="/mypage">
-        <UserIcon />
-      </Link>
+      {isLoggedIn ? (
+        <Link href="/mypage">
+          <UserIcon />
+        </Link>
+      ) : (
+        <Link
+          href="/mypage"
+          className="flex h-full w-72 items-center justify-center rounded-[6px] bg-black text-14 font-400 text-white"
+        >
+          시작하기
+        </Link>
+      )}
     </header>
   );
 };


### PR DESCRIPTION
## 개요

앱바의 로그인 버튼을 로그인 여부에 따라 다른 버튼 디자인으로 보이도록 수정했습니다.
공유하기 버튼을 디자인 수정사항에 따라 더 가시성이 높은 디자인을 수정했습니다.

## 변경사항

<img width="525" alt="스크린샷 2025-01-21 오후 6 11 15" src="https://github.com/user-attachments/assets/b120a892-1c51-4346-9624-c36a5ef09961" />

<img width="525" alt="스크린샷 2025-01-21 오후 6 11 02" src="https://github.com/user-attachments/assets/169806a5-44d8-446e-9800-aca1d1bc19c9" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

