### PR TITLE
fix: 토스 위젯 렌더링 중 결제 버튼 비활성화

### DIFF
--- a/src/app/mypage/shuttle/components/ReservationCard.tsx
+++ b/src/app/mypage/shuttle/components/ReservationCard.tsx
@@ -79,7 +79,8 @@ const ReservationCard = ({
           />
         </div>
         <div className="flex flex-col">
-          <span className="pb-4 text-16 font-500 text-grey-900">
+          <span className="line-clamp-1 pb-4 text-16 font-500 text-grey-900">
+            [{reservation.shuttleRoute.name}]{' '}
             {reservation.shuttleRoute.event.eventName}
           </span>
           <span className="text-12 font-400 text-grey-900">
@@ -88,11 +89,8 @@ const ReservationCard = ({
           <span className="text-12 font-400 text-grey-900">
             {parsedShuttleDate} 셔틀
           </span>
-          <span className="flex gap-12 text-12 font-400 text-grey-500">
-            <span>
-              {reservation.shuttleRoute.name} (
-              {TRIP_STATUS_TO_STRING[reservation.type]})
-            </span>
+          <span className="flex gap-8 text-12 font-400 text-grey-500">
+            <span>{TRIP_STATUS_TO_STRING[reservation.type]}</span>
             <span>{reservation.passengers?.length}인</span>
           </span>
           <span className="pt-4 text-14 font-500 text-grey-900">

--- a/src/app/reservation/[id]/write/components/steps/payment-step/TossPayments.tsx
+++ b/src/app/reservation/[id]/write/components/steps/payment-step/TossPayments.tsx
@@ -30,11 +30,14 @@ const TossPayments = ({ handlePrevStep }: Props) => {
   const pathname = usePathname();
   const { getValues, control } = useFormContext<ReservationFormValues>();
 
-  const [loaded, setLoaded] = useState(false);
+  const [scriptLoaded, setScriptLoaded] = useState(false);
+  const [tossInitialized, setTossInitialized] = useState(false);
   const [tossWidgets, setTossWidgets] = useState<TossPaymentsWidgets | null>(
     null,
   );
   const [loading, setLoading] = useState(false);
+  const buttonDisabled =
+    !scriptLoaded || !tossInitialized || !tossWidgets || loading;
 
   const loadUserId = useCallback(async () => {
     try {
@@ -90,6 +93,7 @@ const TossPayments = ({ handlePrevStep }: Props) => {
         selector: '#agreement',
         variantKey: 'AGREEMENT',
       });
+      setTossInitialized(true);
     } catch (e) {
       const error = e as CustomError;
       console.error(error);
@@ -98,10 +102,10 @@ const TossPayments = ({ handlePrevStep }: Props) => {
   }, []);
 
   useEffect(() => {
-    if (loaded) {
+    if (scriptLoaded) {
       initializeTossPayments();
     }
-  }, [loaded]);
+  }, [scriptLoaded]);
 
   const finalPrice = useWatch({
     control,
@@ -181,11 +185,11 @@ const TossPayments = ({ handlePrevStep }: Props) => {
       <BottomBar
         handlePayment={handlePayment}
         handlePrevStep={handlePrevStep}
-        loading={loading}
+        disabled={buttonDisabled}
       />
       <Script
         src="https://js.tosspayments.com/v2/standard"
-        onReady={() => setLoaded(true)}
+        onReady={() => setScriptLoaded(true)}
         strategy="afterInteractive"
       />
     </>
@@ -197,13 +201,13 @@ export default TossPayments;
 interface BottomBarProps {
   handlePayment: () => void;
   handlePrevStep: () => void;
-  loading: boolean;
+  disabled: boolean;
 }
 
 const BottomBar = ({
   handlePayment,
   handlePrevStep,
-  loading,
+  disabled,
 }: BottomBarProps) => {
   const { control } = useFormContext<ReservationFormValues>();
   const finalPrice = useWatch({
@@ -216,7 +220,7 @@ const BottomBar = ({
       <Button type="button" variant="secondary" onClick={handlePrevStep}>
         이전
       </Button>
-      <Button type="button" disabled={loading} onClick={handlePayment}>
+      <Button type="button" disabled={disabled} onClick={handlePayment}>
         {finalPrice.toLocaleString()}원 결제하기
       </Button>
     </div>


### PR DESCRIPTION
## 개요

토스 위젯이 렌더링 되는 도중 결제 버튼이 비활성화 되도록 했습니다.



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).