### PR TITLE
feat: 디자이너 요청사항 반영(서비스 준비중 모달, 로그인 페이지 디자인) 및 qa사항 반영(푸터 아이콘 링크 연결)

### DIFF
--- a/src/app/(home)/@modal/page.tsx
+++ b/src/app/(home)/@modal/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import ConfirmModal from '@/components/modals/confirm/ConfirmModal';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+const Page = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  const push = useRouter().push;
+
+  return (
+    <>
+      <ConfirmModal
+        isOpen={isOpen}
+        onClosed={() => setIsOpen(false)}
+        onConfirm={() => {
+          push('https://mvp.handybus.co.kr/');
+        }}
+        title="서비스 준비 중이에요"
+        description="더 나은 경험을 제공하기 위해 준비 중이에요.
+예약이 가능한 기존 사이트로 이동합니다."
+        buttonLabels={{ back: '닫기', confirm: '이동하기' }}
+      />
+    </>
+  );
+};
+
+export default Page;

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -7,6 +7,7 @@ interface Props {
   bot: ReactNode;
   reservation: ReactNode;
   demand: ReactNode;
+  modal: ReactNode;
 }
 
 export default function WithFooterLayout({
@@ -14,6 +15,7 @@ export default function WithFooterLayout({
   bot,
   reservation,
   demand,
+  modal,
 }: Readonly<Props>) {
   return (
     <div className="flex h-full flex-grow flex-col">
@@ -23,6 +25,7 @@ export default function WithFooterLayout({
         {reservation}
         {demand}
         {bot}
+        {modal}
       </main>
       <Footer />
     </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Logo from 'public/icons/logo-large-white.svg';
+import LogoLarge from 'public/icons/logo-large.svg';
 import Kakao from 'public/icons/kakao.svg';
 import Naver from 'public/icons/naver.svg';
 import Link from 'next/link';
@@ -25,13 +25,13 @@ const Login = ({ searchParams }: Props) => {
   }, [searchParams]);
 
   return (
-    <main className="flex grow flex-col items-center bg-primary-main">
+    <main className="flex grow flex-col items-center bg-white">
       <div className="my-auto flex flex-col items-center">
-        <span className="text-18 font-500 text-white">집부터 콘서트장까지</span>
-        <span className="mb-32 text-28 font-700 text-white">
+        <span className="text-18 font-500 text-black">집부터 콘서트장까지</span>
+        <span className="mb-32 text-28 font-700 text-black">
           핸디버스와 함께
         </span>
-        <Logo />
+        <LogoLarge viewBox="0 0 121 75" width={215} height={108} />
       </div>
       <div className="mb-16 flex flex-col gap-8">
         <Link

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -18,15 +18,27 @@ const Footer = () => {
         성신여자대학교운정그린캠퍼스)
       </div>
       <div className="flex gap-16">
-        <button>
+        <a
+          href="https://www.instagram.com/handy.bus/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <InstagramIcon />
-        </button>
-        <button>
+        </a>
+        <a
+          href="https://x.com/Handy_Bus?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <TwitterIcon />
-        </button>
-        <button>
+        </a>
+        <a
+          href="https://blog.naver.com/handy_bus"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <NaverBlogIcon />
-        </button>
+        </a>
       </div>
       <div className="text-12 font-600 text-grey-500">
         <Link href="/policy">이용약관</Link>


### PR DESCRIPTION
## 개요
- 디자이너님 요청사항을 반영했습니다.
  - 홈에서 기존 서비스로 리디렉션되는 안내 모달 추가
  - 로그인 페이지 디자인 색상 변경
- 푸터의 인스타 트위터 블로그 아이콘의 링크를 연결하였습니다.

<img width="336" alt="Screenshot 2025-01-22 at 11 23 52 AM" src="https://github.com/user-attachments/assets/cec662a7-df2b-4353-8d64-79e886954a30" />
<img width="339" alt="Screenshot 2025-01-22 at 11 23 46 AM" src="https://github.com/user-attachments/assets/18d91f3d-f280-43eb-9d50-bb1932312de8" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).