### PR TITLE
fix: confirm 모달에 다양한 variant options 추가 및 홈의 서비스 준비중 모달에 primary variant 추가

### DIFF
--- a/src/app/(home)/@modal/page.tsx
+++ b/src/app/(home)/@modal/page.tsx
@@ -20,6 +20,7 @@ const Page = () => {
         description="더 나은 경험을 제공하기 위해 준비 중이에요.
 예약이 가능한 기존 사이트로 이동합니다."
         buttonLabels={{ back: '닫기', confirm: '이동하기' }}
+        variant="primary"
       />
     </>
   );

--- a/src/components/modals/confirm/ConfirmModal.tsx
+++ b/src/components/modals/confirm/ConfirmModal.tsx
@@ -16,6 +16,7 @@ interface Props {
   isOpen: boolean;
   onClosed: () => void;
   disabled?: boolean;
+  variant?: 'alert' | 'primary' | 'secondary' | 'modalSecondary' | 'none';
 }
 
 const ConfirmModal = ({
@@ -26,6 +27,7 @@ const ConfirmModal = ({
   isOpen,
   onClosed,
   disabled = false,
+  variant,
 }: Props) => {
   return (
     <CustomModal
@@ -40,6 +42,7 @@ const ConfirmModal = ({
         description={description}
         buttonLabels={buttonLabels}
         disabled={disabled}
+        variant={variant}
       />
     </CustomModal>
   );
@@ -54,6 +57,7 @@ interface ConfirmModalContentProps {
   description: string;
   buttonLabels: ButtonLabels;
   disabled?: boolean;
+  variant?: 'alert' | 'primary' | 'secondary' | 'modalSecondary' | 'none';
 }
 
 const ConfirmModalContent = ({
@@ -63,6 +67,7 @@ const ConfirmModalContent = ({
   description,
   buttonLabels,
   disabled = false,
+  variant = 'alert',
 }: ConfirmModalContentProps) => {
   return (
     <>
@@ -84,7 +89,7 @@ const ConfirmModalContent = ({
         <Button variant="modalSecondary" onClick={onClosed}>
           {buttonLabels.back}
         </Button>
-        <Button variant="alert" onClick={onConfirm} disabled={disabled}>
+        <Button variant={variant} onClick={onConfirm} disabled={disabled}>
           {buttonLabels.confirm}
         </Button>
       </div>


### PR DESCRIPTION
## 개요
- confirm 모달에 다양한 variant options 추가 
- 홈의 서비스 준비중 모달에 primary variant 추가

<img width="342" alt="Screenshot 2025-01-22 at 2 04 13 PM" src="https://github.com/user-attachments/assets/06863634-59e4-4ffe-8224-e8349d447878" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).