### PR TITLE
fix: production 환경에서만 안내 모달 표시

### DIFF
--- a/src/app/(home)/@modal/page.tsx
+++ b/src/app/(home)/@modal/page.tsx
@@ -5,7 +5,9 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 const Page = () => {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(
+    process.env.NODE_ENV === 'production' ? true : false,
+  );
   const push = useRouter().push;
 
   return (


### PR DESCRIPTION
## 개요
개발환경에서는 홈에서 불필요한 서비스 준비중 안내 모달이 뜨지 않습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).