### PR TITLE
fix: 버스 배정 상태에 따라 핸디 오픈채팅링크 제출 활성화

### DIFF
--- a/src/app/mypage/shuttle/[id]/handy/page.tsx
+++ b/src/app/mypage/shuttle/[id]/handy/page.tsx
@@ -6,10 +6,39 @@ import TextInput from '@/components/inputs/text-input/TextInput';
 import { CustomError } from '@/services/custom-error';
 import { usePutShuttleBus } from '@/services/shuttle-operation.service';
 import { useGetUserReservation } from '@/services/user-management.service';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
+
+const HANDY_GUIDE_URL = process.env.NEXT_PUBLIC_HANDY_GUIDE_URL ?? '';
+
+const TEXT = {
+  busAssigned: {
+    description: (
+      <>
+        개설한 오픈채팅방으로 다른 탑승객분들이 입장할 수 있도록 링크를
+        입력해주세요.
+        <br />
+        <br />
+        자세한 개설 방법은 ‘핸디 가이드 보러가기’에서 확인하실 수 있어요.
+      </>
+    ),
+    placeholder: '오픈채팅방 링크를 입력해주세요',
+  },
+  busNotAssigned: {
+    description: (
+      <>
+        개설한 오픈채팅방으로 다른 탑승객분들이 입장할 수 있도록 링크를
+        입력해주세요. 링크 입력은 버스 배정 후 가능하며, 배정이 완료되면 바로
+        알려드릴게요.
+        <br />
+        <br />
+        자세한 개설 방법은 ‘핸디 가이드 보러가기’에서 확인하실 수 있어요.
+      </>
+    ),
+    placeholder: '버스 배정 후 입력할 수 있습니다.',
+  },
+};
 
 interface FormValues {
   openChatLink: string;
@@ -59,6 +88,12 @@ const Handy = ({ params }: Props) => {
     });
   };
 
+  const openHandyGuide = () => {
+    window.open(HANDY_GUIDE_URL);
+  };
+
+  const isBusAssigned = data?.reservation.shuttleBusId !== null;
+
   return (
     <>
       <AppBar>핸디 가이드</AppBar>
@@ -76,22 +111,19 @@ const Handy = ({ params }: Props) => {
             <br />
             자세한 핸디 가이드는 아래 링크를 확인해주세요!
           </p>
-          <Link
-            href={process.env.NEXT_PUBLIC_HANDY_GUIDE_URL ?? ''}
+          <Button
+            onClick={openHandyGuide}
             className="mx-auto mt-[60px] block w-fit rounded-full bg-grey-100 px-16 text-grey-600-sub"
-            target="_blank"
           >
             핸디 가이드 보러가기
-          </Link>
+          </Button>
         </section>
         <section className="py-[60px]">
           <h2 className="pb-12 text-28 font-700">오픈채팅방 링크 입력</h2>
           <p className="pb-24 text-16 font-400 text-grey-700">
-            개설한 오픈채팅방으로 다른 탑승객분들이 입장할 수 있도록 링크를
-            입력해주세요.
-            <br />
-            <br />
-            자세한 개설 방법은 ‘핸디 가이드 보러가기’에서 확인하실 수 있어요.
+            {isBusAssigned
+              ? TEXT.busAssigned.description
+              : TEXT.busNotAssigned.description}
           </p>
           <form
             className="flex flex-col gap-12"
@@ -101,11 +133,17 @@ const Handy = ({ params }: Props) => {
               name="openChatLink"
               control={control}
               setValue={setValue}
-              placeholder="오픈채팅방 링크를 입력해주세요"
+              placeholder={
+                isBusAssigned
+                  ? TEXT.busAssigned.placeholder
+                  : TEXT.busNotAssigned.placeholder
+              }
             >
               링크 입력
             </TextInput>
-            <Button>링크 제출하기</Button>
+            <Button type="submit" disabled={!isBusAssigned}>
+              링크 제출하기
+            </Button>
           </form>
         </section>
       </main>


### PR DESCRIPTION
## 개요

버스 배정 상태에 따라 핸디의 오픈채팅링크 입력 폼이 활성화 되도록 했습니다.

## 변경사항

<img width="446" alt="스크린샷 2025-01-23 오후 6 27 53" src="https://github.com/user-attachments/assets/88c26f24-c3ee-4c76-b7fa-aeeec840f8fb" />

<img width="448" alt="스크린샷 2025-01-23 오후 6 29 59" src="https://github.com/user-attachments/assets/e4ab0450-1743-4697-9bfa-a4da9d91b33b" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

