### PR TITLE
fix(예약하기): 카카오톡문의하기 링크 추가

### DIFF
--- a/src/app/reservation/[id]/write/components/steps/PassengerInfoStep.tsx
+++ b/src/app/reservation/[id]/write/components/steps/PassengerInfoStep.tsx
@@ -83,7 +83,16 @@ const PassengerInfoStep = ({ handleNextStep, handlePrevStep }: Props) => {
           max={Math.min(maxPassengerCount, 9)}
         />
         <p className="text-12 font-400 text-grey-500">
-          10명 이상 예약하는 경우, <u>핸디버스 카카오 채널</u>로 문의 바랍니다.
+          10명 이상 예약하는 경우,{' '}
+          <a
+            href="http://pf.kakao.com/_AxncxhG"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            핸디버스 카카오 채널
+          </a>
+          로 문의 바랍니다.
         </p>
       </section>
       <section className="py-28">


### PR DESCRIPTION
## 개요
예약하기에서 카카오톡 문의하기 링크가 빠져있던 문제를 해결하였습니다.
![image](https://github.com/user-attachments/assets/b3a4d820-d106-4565-a6ee-0447e14e4c09)

## 변경사항
어떤 변경 사항이 있나요?

아래의 내용을 포함하면 좋습니다.
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).