### PR TITLE
style: 컴포넌트 이름 변경

### DIFF
--- a/src/components/route-visualizer/RouteVisualizer.tsx
+++ b/src/components/route-visualizer/RouteVisualizer.tsx
@@ -39,7 +39,7 @@ const RouteVisualizer = ({
   return (
     <section className="flex flex-col gap-16">
       <header>
-        <h2 className="text-22 font-700 leading-[30.8px]">셔틀 예상 노선</h2>
+        <h2 className="text-22 font-700 leading-[30.8px]">셔틀 노선</h2>
         <p className="text-14 font-500 leading-[22.4px] text-grey-500">
           예약 현황에 따라 추가 경유지가 발생하거나 시각이 변동될 수 있습니다.
         </p>


### PR DESCRIPTION
## 개요

셔틀 예상 노선 -> 셔틀 노선으로 ShuttleVisulaizer 컴포넌트의 표시 이름이 변경되었습니다.

<img width="461" alt="Screenshot 2025-02-06 at 3 33 03 PM" src="https://github.com/user-attachments/assets/5c959904-bf18-4e86-91ef-bef91d822944" />

<img width="396" alt="Screenshot 2025-02-06 at 3 31 30 PM" src="https://github.com/user-attachments/assets/5c8302a4-c1a3-4045-af31-a15e4a72077c" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).