### PR TITLE
fix(예약하기): 결제 실패이지만 예약완료일 수 있는 이슈 핸들링

### DIFF
--- a/src/app/reservation/[id]/write/components/steps/payment-step/TossPayments.tsx
+++ b/src/app/reservation/[id]/write/components/steps/payment-step/TossPayments.tsx
@@ -155,7 +155,10 @@ const TossPayments = ({ handlePrevStep }: Props) => {
         readyPaymentFormValues,
       );
 
-      const successUrl = window.location.origin + pathname + `/payments`;
+      const successUrl =
+        window.location.origin +
+        pathname +
+        `/payments?reservationId=${postReservationResponse.reservationId}`;
       const failUrl = window.location.origin + pathname + `/payments/fail`;
 
       await tossWidgets.requestPayment({

--- a/src/app/reservation/[id]/write/payments/fail/page.tsx
+++ b/src/app/reservation/[id]/write/payments/fail/page.tsx
@@ -37,10 +37,10 @@ const Page = ({ searchParams }: Props) => {
       <LogoLargeIcon viewBox="0 0 121 75" width="90px" height="44px" />
       <section>
         <h1 className="flex justify-center text-28 font-700 leading-[39.2px] text-black">
-          결제가 실패했어요
+          결제 중 문제가 생겼습니다.
         </h1>
         <p className="flex justify-center text-16 font-500 leading-[25.6px] text-grey-500">
-          처음부터 다시 시도해주세요.
+          마이페이지에서 결제 내역을 확인한 후 다시 시도해주세요.
         </p>
       </section>
       <div className="fixed bottom-0 left-0 right-0 mx-auto max-w-500 p-16">

--- a/src/utils/setTimeoutWithRetry.ts
+++ b/src/utils/setTimeoutWithRetry.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const setTimeoutWithRetry = (
+  fn: () => Promise<any>,
+  maxRetries: number,
+  delay: number,
+): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    let tries = 0;
+
+    const attempt = () => {
+      fn()
+        .then(resolve)
+        .catch((error) => {
+          tries++;
+          if (tries < maxRetries) {
+            setTimeout(attempt, delay);
+          } else {
+            reject(error);
+          }
+        });
+    };
+
+    attempt();
+  });
+};


### PR DESCRIPTION
## 이슈 해결 및 리팩토링
### 1. 이슈해결
#### 문제상황
 : 토스페이먼츠 결제 후 결제중 페이지에서 **중지 혹은 새로고침**을 눌렀을때 문제가 야기될 수 있습니다. 
구체적인 예시로, 중지 버튼을 눌렀을때 `결제승인 API`(/v1/billing/payments/{paymentId} 이하 결제승인 API라고 부르겠습니다) response를 받지 않고 `cancled` 처리되어 fail url로 리디렉트되는 경우가 생길 수 있습니다. 그러나 화면에서 `결제 실패`라고 표기되나 결제승인 API는 완료되어서 `성공`했을 수 있음. 

```
참고. /v1/billing/payments/{paymentId} 의 케이스 별 응답 상태

첫시도 : 특이사항 없음. 정상적으로 응답 처리
앞선 요청 처리중, Request 재시도 : 앞의 api 결과 기다렸다가 전달
앞선 요청 처리완료, 5초 안에 재시도 : 앞선 api결과 
앞선 요청 처리완료, 5초 이후 재시도 : 다시 결제 승인 처리 -> 409, 이미 처리된 결제입니다 에러발생
```

#### 개선
 : 추가로 해당유저(나)의 `reservation status`를 조회해서 `PAYMENT_COMPLETE` 일 경우 결제 성공 url로 리디렉션 처리됩니다. (duration 3000ms, max retry 3s 로 reservation status를 확인합니다)

#### 결과
(1) 중지 -> post payment API가 처리완료되면 polling으로 유저(나)의 reservation status를 추적해 자동으로 성공/실패 url로 리디렉션됨
(2) 새로고침 -> post payment 재요청 -> 성공/실패 url 로 리디렉션
(3) 5초 이상 새로고침 -> 409, 이미 처리된 결제입니다 에러발생 -> 실패 url로 리디렉션

### 2. 결제 실패 안내 메세지 문구 변경
결제가 실패했다고 안내되었지만, 마이페이지에서 확인해보면 결제완료된 상황이 존재할 수 있습니다.
결제 실패라고 단언하기보다 좀 더 많은 케이스를 담을 수 있는 안내 메시지로 변경합니다.

#### 문구 설명
결제가 실패했어요 -> 결제중 문제가 생겼습니다.
처음부터 다시 시도해주세요. -> 마이페이지에서 결제내역을 확인한 후 다시 시도해주세요.

#### UI
<img width="337" alt="Screenshot 2025-02-10 at 11 43 21 AM" src="https://github.com/user-attachments/assets/f9adfff5-ee3d-41cf-8cc1-0f7c08037ba5" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).