### PR TITLE
fix: reservation createdAt 대신 payment createdAt 을 부분환불계산로직에 반영

### DIFF
--- a/src/app/mypage/shuttle/components/CancelBottomSheet.tsx
+++ b/src/app/mypage/shuttle/components/CancelBottomSheet.tsx
@@ -38,10 +38,10 @@ const CancelBottomSheet = ({
     () =>
       calculateRefundFee({
         paymentAmount: reservation?.paymentAmount ?? undefined,
-        createdAt: dayjs(reservation?.createdAt),
+        createdAt: dayjs(reservation?.paymentCreatedAt),
         dDay,
       }),
-    [reservation?.paymentAmount, reservation?.createdAt, dDay],
+    [reservation?.paymentAmount, reservation?.paymentCreatedAt, dDay],
   );
 
   useEffect(() => {
@@ -58,7 +58,7 @@ const CancelBottomSheet = ({
     if (!reservation) {
       return false;
     }
-    const reservationDate = new Date(reservation.createdAt);
+    const paymentDate = new Date(reservation.paymentCreatedAt ?? '');
     const shuttleDate = new Date(
       reservation.shuttleRoute.event.dailyEvents.find(
         (dailyEvent) =>
@@ -67,8 +67,9 @@ const CancelBottomSheet = ({
     );
     const currentDate = new Date();
 
-    const diffTime = currentDate.getTime() - reservationDate.getTime();
+    const diffTime = currentDate.getTime() - paymentDate.getTime();
     if (diffTime < REFUND_DDAY_TIME_LIMIT) {
+      console.log('diffTime', diffTime);
       return true;
     }
     const diffDays = Math.ceil(
@@ -76,6 +77,7 @@ const CancelBottomSheet = ({
     );
 
     if (diffDays > REFUND_DAY_LIMIT) {
+      console.log('diffDays', diffDays);
       return true;
     }
     return false;
@@ -116,6 +118,7 @@ const CancelBottomSheet = ({
               <DynamicCancellationAndRefundContent
                 dDay={dDay}
                 refundFee={refundFee}
+                isRefundable={isRefundable}
               />
               <div className="flex gap-8 py-16">
                 <Button

--- a/src/app/mypage/shuttle/components/DynamicNoticeSection.tsx
+++ b/src/app/mypage/shuttle/components/DynamicNoticeSection.tsx
@@ -3,11 +3,13 @@ import { Dayjs } from 'dayjs';
 interface Props {
   dDay?: Dayjs;
   refundFee?: number;
+  isRefundable?: boolean;
 }
 
 export const DynamicCancellationAndRefundContent = ({
   dDay,
   refundFee,
+  isRefundable,
 }: Props) => {
   return (
     <section className="flex flex-col gap-16">
@@ -41,7 +43,7 @@ export const DynamicCancellationAndRefundContent = ({
             <tr>
               <td className="border-b border-r border-grey-300 p-12">
                 {dDay
-                  ? `~ ${dDay.subtract(8, 'day').format('YYYY.MM.DD')} 23:59 이전`
+                  ? `~ ${dDay.subtract(8, 'day').format('MM.DD')} 23:59 이전`
                   : '~ 탑승 D-8 23:59'}
               </td>
               <td className="border-b border-grey-300 p-12">수수료 없음</td>
@@ -49,7 +51,7 @@ export const DynamicCancellationAndRefundContent = ({
             <tr>
               <td className="border-b border-r border-grey-300 p-12">
                 {dDay
-                  ? `~ ${dDay.subtract(7, 'day').format('YYYY.MM.DD')} 23:59 이전`
+                  ? `~ ${dDay.subtract(7, 'day').format('MM.DD')} 23:59 이전`
                   : '~ 탑승 D-7 23:59'}
               </td>
               <td className="border-b border-grey-300 p-12">결제 금액의 25%</td>
@@ -57,7 +59,7 @@ export const DynamicCancellationAndRefundContent = ({
             <tr>
               <td className="border-b border-r border-grey-300 p-12">
                 {dDay
-                  ? `~ ${dDay.subtract(6, 'day').format('YYYY.MM.DD')} 23:59 이전`
+                  ? `~ ${dDay.subtract(6, 'day').format('MM.DD')} 23:59 이전`
                   : '~ 탑승 D-6 23:59'}
               </td>
               <td className="border-b border-grey-300 p-12">결제 금액의 50%</td>
@@ -65,7 +67,7 @@ export const DynamicCancellationAndRefundContent = ({
             <tr>
               <td className="border-r border-grey-300 p-12">
                 {dDay
-                  ? `${dDay.subtract(5, 'day').format('YYYY.MM.DD')} 00:00 ~`
+                  ? `${dDay.subtract(5, 'day').format('MM.DD')} 00:00 ~`
                   : '탑승 D-5 00:00 ~'}
               </td>
               <td className="p-12">취소 / 환불 불가</td>
@@ -74,9 +76,9 @@ export const DynamicCancellationAndRefundContent = ({
         </table>
       </section>
 
-      {dDay && (
+      {dDay && isRefundable && (
         <p className="flex items-center justify-center rounded-[4px] bg-grey-50 p-8 text-14 font-700 leading-[18px] text-red-500">
-          취소 수수료: {refundFee}원
+          취소 수수료: {refundFee?.toLocaleString()}원
         </p>
       )}
     </section>

--- a/src/app/mypage/shuttle/utils/calculateRefundFee.util.ts
+++ b/src/app/mypage/shuttle/utils/calculateRefundFee.util.ts
@@ -10,9 +10,10 @@ export const calculateRefundFee = ({
   dDay?: Dayjs;
 }): number | undefined => {
   if (!paymentAmount || !createdAt || !dDay) return undefined;
-
+  console.log('[calculateRefundFee] dDay', dDay);
   let refundableAmount = 0;
   const now = dayjs().startOf('day');
+  console.log('[calculateRefundFee] now', now);
 
   // dDay와 now의 차이를 "일" 단위로 계산 (정수값)
   const daysUntilEvent = dDay.diff(now, 'day');


### PR DESCRIPTION
## 개요

- 부분환불로직에서 발견된 이슈를 해결하였습니다.
  - 문제 : D-DAY 날짜 계산과 수수료 및 버튼 활성 상태맞지 않음

- 환불이 불가능할 땐 취소 수수료를 보여주지 않습니다.
- 취소 수수료에 localeString을 적용했습니다. (10000 -> 10,000)
- 환불 일자에 더이상 년 단위를 표시하지 않습니다
<img width="387" alt="Screenshot 2025-02-11 at 2 30 35 PM" src="https://github.com/user-attachments/assets/a32bd8a0-950d-4fe3-a52a-d1b15676e57a" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).