### PR TITLE
feat: 모든 행사일의 수요조사 반영 및 편도 수요조사 안되던 버그 해결

### DIFF
--- a/src/app/demand/[id]/components/DemandForm.tsx
+++ b/src/app/demand/[id]/components/DemandForm.tsx
@@ -133,15 +133,13 @@ const DemandForm = ({ event }: Props) => {
         </section>
       </form>
       <div id="divider" className="my-16 h-[8px] bg-grey-50" />
-      {selectedDailyEvent && (
-        <DemandStats
-          eventId={event.eventId}
-          dailyEvent={selectedDailyEvent}
-          bigRegion={selectedBigRegion}
-          smallRegion={selectedSmallRegion}
-          location={event.eventLocationName}
-        />
-      )}
+      <DemandStats
+        eventId={event.eventId}
+        dailyEvent={selectedDailyEvent}
+        bigRegion={selectedBigRegion}
+        smallRegion={selectedSmallRegion}
+        location={event.eventLocationName}
+      />
       <BottomBar
         eventName={event.eventName}
         isNotOpen={event.eventStatus !== 'OPEN'}

--- a/src/app/demand/[id]/components/DemandStats.tsx
+++ b/src/app/demand/[id]/components/DemandStats.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import { useGetEventDemandStats } from '@/services/shuttle-operation.service';
+import {
+  useGetAllEventDemandStats,
+  useGetEventDemandStats,
+} from '@/services/shuttle-operation.service';
 import { DailyEvent } from '@/types/shuttle-operation.type';
 import { dateString } from '@/utils/dateString.util';
 
 interface Props {
   eventId: string;
-  dailyEvent: DailyEvent;
+  dailyEvent?: DailyEvent;
   location: string;
   bigRegion?: string;
   smallRegion?: string;
@@ -19,11 +22,15 @@ const DemandStats = ({
   bigRegion,
   smallRegion,
 }: Props) => {
-  const { data: demandStats } = useGetEventDemandStats(
+  const { data: eventDemandStats } = useGetEventDemandStats(
     eventId,
-    dailyEvent.dailyEventId,
+    dailyEvent?.dailyEventId ?? '',
     { provinceFullName: bigRegion, cityFullName: smallRegion },
   );
+
+  const { data: allEventDemandStats } = useGetAllEventDemandStats(eventId);
+
+  const demandStats = dailyEvent ? eventDemandStats : allEventDemandStats;
 
   const region =
     bigRegion && smallRegion ? bigRegion + ' ' + smallRegion : undefined;
@@ -36,7 +43,9 @@ const DemandStats = ({
         </h2>
         <p className="pb-16 pt-4 text-14 font-500 leading-[22.4px] text-grey-500">
           이번 콘서트를 위해{' '}
-          <span className="text-grey-700">{dateString(dailyEvent.date)}</span>
+          <span className="text-grey-700">
+            {dailyEvent ? dateString(dailyEvent.date) : '전체'}
+          </span>
           {region ? (
             <>
               에 <span className="text-grey-700">{region}</span>를 지나는{' '}

--- a/src/app/demand/[id]/write/components/WriteForm.tsx
+++ b/src/app/demand/[id]/write/components/WriteForm.tsx
@@ -99,20 +99,30 @@ const WriteForm = ({ event, dailyEventId, regionId }: Props) => {
         regionId: formValues.regionId,
         type: formValues.type,
         passengerCount: 1,
-        toDestinationRegionHub: {
-          regionHubId:
-            formValues.toDestinationRegionHub?.regionHubId ?? undefined,
-          desiredRegionHub: formValues.toDestinationRegionHub
-            ? formValues.toDestinationDesiredRegionHub
-            : undefined,
-        },
-        fromDestinationRegionHub: {
-          regionHubId:
-            formValues.fromDestinationRegionHub?.regionHubId ?? undefined,
-          desiredRegionHub: formValues.fromDestinationDesiredRegionHub
-            ? formValues.fromDestinationDesiredRegionHub
-            : undefined,
-        },
+        ...(formValues.type === 'ROUND_TRIP' ||
+        formValues.type === 'TO_DESTINATION'
+          ? {
+              toDestinationRegionHub: {
+                regionHubId:
+                  formValues.toDestinationRegionHub?.regionHubId ?? undefined,
+                desiredRegionHub: formValues.toDestinationRegionHub
+                  ? formValues.toDestinationDesiredRegionHub
+                  : undefined,
+              },
+            }
+          : {}),
+        ...(formValues.type === 'ROUND_TRIP' ||
+        formValues.type === 'FROM_DESTINATION'
+          ? {
+              fromDestinationRegionHub: {
+                regionHubId:
+                  formValues.fromDestinationRegionHub?.regionHubId ?? undefined,
+                desiredRegionHub: formValues.fromDestinationDesiredRegionHub
+                  ? formValues.fromDestinationDesiredRegionHub
+                  : undefined,
+              },
+            }
+          : {}),
       },
     });
   };

--- a/src/services/shuttle-operation.service.ts
+++ b/src/services/shuttle-operation.service.ts
@@ -411,6 +411,25 @@ export const useDeleteDemand = () => {
   });
 };
 
+export const getAllEventDemandStats = async (eventId: string) => {
+  const res = await instance.get(
+    `/v2/shuttle-operation/events/${eventId}/dates/all/demands/all/stats`,
+    {
+      shape: {
+        statistic: EventDemandStatsSchema,
+      },
+    },
+  );
+  return res.statistic;
+};
+
+export const useGetAllEventDemandStats = (eventId: string) =>
+  useQuery({
+    queryKey: ['demand', 'stats', eventId],
+    queryFn: () => getAllEventDemandStats(eventId),
+    enabled: Boolean(eventId),
+  });
+
 export const getEventDemandStats = async (
   eventId: string,
   dailyEventId: string,


### PR DESCRIPTION
## 개요
- 이제 수요조사 페이지에 들어왔을때부터 일일행사의 모든 수요를 합쳐서 보여줍니다.
- 편도행 수요신청 안되던 버그가 고쳐졌습니다.

https://github.com/user-attachments/assets/dae1c376-4930-4ef6-ba66-82d5f7d3c89f


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).