### PR TITLE
feat: 홈의 수요조사/예약카드 셔틀일자 빠른순으로 정렬

### DIFF
--- a/src/app/(home)/@demand/page.tsx
+++ b/src/app/(home)/@demand/page.tsx
@@ -3,6 +3,7 @@ import RedirectButton from '@/components/buttons/redirect-button/RedirectButton'
 import DemandView from './components/DemandView';
 import dynamic from 'next/dynamic';
 import { getEvents } from '@/services/shuttle-operation.service';
+import { toSorted } from '@/app/demand/utils/toSorted.util';
 const Empty = dynamic(() => import('@/app/demand/components/Empty'));
 
 const Page = () => (
@@ -28,13 +29,12 @@ const SubPage = async () => {
     return <Empty />;
   }
 
-  const sortedEvents = events
-    .slice(0, 5)
-    .sort((a, b) => a.eventName.localeCompare(b.eventName));
+  const sortedEvents = toSorted(events, '셔틀 일자 빠른 순');
+  const slicedEvents = sortedEvents.slice(0, 5);
 
   return (
     <div className="flex flex-col">
-      {sortedEvents.map((event) => (
+      {slicedEvents.map((event) => (
         <DemandView key={event.eventId} event={event} />
       ))}
     </div>

--- a/src/app/(home)/@reservation/page.tsx
+++ b/src/app/(home)/@reservation/page.tsx
@@ -9,6 +9,7 @@ import { toSearchParams } from '@/utils/searchParams.util';
 import { getShuttleRoutes } from '@/services/shuttle-operation.service';
 import { ShuttleRoute } from '@/types/shuttle-operation.type';
 import { getUser } from '@/services/user-management.service';
+import { toSortedRoutes } from '@/app/reservation/util/sort.util';
 
 const Page = async () => {
   const { region, routes, promoted, userRegion } =
@@ -32,9 +33,7 @@ const Page = async () => {
     smallRegion: region?.smallRegion,
   }).toString();
 
-  const sortedRoutes = routes
-    .sort((a, b) => a.remainingSeatCount - b.remainingSeatCount)
-    .slice(0, 16);
+  const sortedRoutes = toSortedRoutes('셔틀 일자 빠른 순', routes).slice(0, 16);
 
   return (
     <Bar regionString={location} postfix={postfix}>

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -10,6 +10,15 @@ interface Props {
   modal: ReactNode;
 }
 
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault('Asia/Seoul');
+dayjs.locale('ko');
+
 export default function WithFooterLayout({
   top,
   bot,

--- a/src/app/demand/page.tsx
+++ b/src/app/demand/page.tsx
@@ -35,7 +35,7 @@ const Page = async ({ searchParams }: Props) => {
 
   const sort = fromString(
     (Array.isArray(searchParams?.sort)
-      ? searchParams?.sort[0]
+      ? searchParams?.sort[1]
       : searchParams?.sort) || '',
   );
 

--- a/src/app/demand/page.tsx
+++ b/src/app/demand/page.tsx
@@ -1,17 +1,15 @@
-import type { DemandSortType } from '@/constants/demand';
 import DemandFilterContainer from './components/DemandFilterContainer';
 import { fromString, toDemandSort } from './utils/param.util';
 import DemandCard from './components/DemandCard';
 import dynamic from 'next/dynamic';
 import { Metadata } from 'next';
 import { getEvents } from '@/services/shuttle-operation.service';
-import { Event } from '@/types/shuttle-operation.type';
-import { dayjsTz } from '@/utils/dayjsTz.util';
 const Empty = dynamic(() => import('./components/Empty'));
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import Header from '@/components/header/Header';
+import { toSorted } from './utils/toSorted.util';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -65,27 +63,3 @@ const Page = async ({ searchParams }: Props) => {
 };
 
 export default Page;
-
-const toSorted = async (events: Event[], sort: DemandSortType) => {
-  let newData: Event[];
-  switch (sort) {
-    // case '수요 신청한 인원이 많은 순':
-    //   newData = events.toSorted(
-    //     (a, b) => a.totalDemandCount - b.totalDemandCount,
-    //   );
-    //   break;
-    case '콘서트 이름 가나다 순':
-      newData = events.toSorted((a, b) =>
-        a.eventName.localeCompare(b.eventName),
-      );
-      break;
-    case '셔틀 일자 빠른 순':
-      newData = events.toSorted(
-        (a, b) =>
-          (dayjsTz(a.dailyEvents[0].date).getTime() || 0) -
-          (dayjsTz(b.dailyEvents[0].date).getTime() || 0),
-      );
-      break;
-  }
-  return newData;
-};

--- a/src/app/demand/utils/toSorted.util.ts
+++ b/src/app/demand/utils/toSorted.util.ts
@@ -1,0 +1,27 @@
+import { DemandSortType } from '@/constants/demand';
+import { Event } from '@/types/shuttle-operation.type';
+import { dayjsTz } from '@/utils/dayjsTz.util';
+
+export const toSorted = (events: Event[], sort: DemandSortType) => {
+  let newData: Event[];
+  switch (sort) {
+    // case '수요 신청한 인원이 많은 순':
+    //   newData = events.toSorted(
+    //     (a, b) => a.totalDemandCount - b.totalDemandCount,
+    //   );
+    //   break;
+    case '콘서트 이름 가나다 순':
+      newData = events.toSorted((a, b) =>
+        a.eventName.localeCompare(b.eventName),
+      );
+      break;
+    case '셔틀 일자 빠른 순':
+      newData = events.toSorted(
+        (a, b) =>
+          (dayjsTz(a.dailyEvents[0].date).getTime() || 0) -
+          (dayjsTz(b.dailyEvents[0].date).getTime() || 0),
+      );
+      break;
+  }
+  return newData;
+};

--- a/src/app/reservation/constants/params.ts
+++ b/src/app/reservation/constants/params.ts
@@ -34,7 +34,7 @@ export const shuttleSortSearchParamsFromString = (
     case 'NAME_ASC':
       return 'NAME_ASC';
     default:
-      return SHUTTLE_SORT_SEARCH_PARAMS[0];
+      return SHUTTLE_SORT_SEARCH_PARAMS[3];
   }
 };
 


### PR DESCRIPTION
## 개요

- 지용님 요청에 의해 (보람님 검수 완) 홈의 카드들을 셔틀일자 빠른순으로 정렬하였습니다.

https://github.com/user-attachments/assets/52ccd5c9-c865-4bd4-a9db-82536233f835

<img width="613" alt="Screenshot 2025-02-14 at 11 18 10 AM" src="https://github.com/user-attachments/assets/3c3d6d91-31f8-4415-b4c8-a8a043177508" />


## 겪은 이슈
로컬에서 빌드시에는 아무런 문제가 없으나, git hook으로 build 시에 에러가 발생함.
에러메세지는 `toSorted is not a function` 이었음.

**다음의 방법으로 해결 할 수 있었습니다.** 
저는 여기서 (2번) PR-CHECKER 에서 불필요한 18버전 빌드테스트를 지움으로서 해결했습니다.
1. 패러렐라우팅을 사용하는 페이지에서 `export const dynamic = 'force-dynamic'; ` 명시적으로 동적 렌더링 강제
2. nodejs 버전을 18v 보다 높게 설정한다.

**그런데 의문점이 생겼습니다.**
- toSorted 는 18v이하에서 지원하지 않음, 
- 현재 제 로컬 nodejs 버전과 vercel 배포환경 nodejs 버전은 모두 18v 보다 높아서 빌드시 에러가 발생하지 않았음.
- git hook 환경에서는 node version 이 18 버전이라 에러가 발생함.
엄밀한 원인 파악을 위해서 제 로컬 nodejs 버전을 18 버전으로 변경하고, 패러랠라우팅을 사용하는 페이지에 toSorted 를 사용했을때 빌드해보았는데요. 패러렐라우팅을 사용하는 페이지에서만 static site generating 에러가 발생했습니다. 
정말 이상한건 reservation/, demand/ 에서도 toSorted를 사용하는데 여기서는 static site generating 에러가 발생하지 않았습니다.

**핵심 의문점을 정리하면 다음과 같아요.**
`SSG 빌드 과정에서 왜 패러랠라우팅 페이지에서는 에러가 발생하고, 그 외 서버컴포넌트 페이지에서는 에러가 발생하지 않는가?`
아래를 읽으시면 자세히 이해하시겠지만 좀 더 정제된 의문점은 다음과 같아요.
- SSG도 빌드 과정에서 트랜스파일링을 거치는데 왜 에러가 발생하는가?
- 동일한 Node.js v18 환경인데 왜 런타임에서는 정상 동작하는가?

**결론부터 말하자면,** 
1. 기본적으로 searchParams, 동적 fetch 등 동적렌더링이 필요한 페이지라면 Nextjs는 SSG를 시도하지 않는다.
2. 그러나 패러랠라우팅을 사용하는 페이지는 Next.js 가 우선적으로 SSG(정적렌더링) 를 시도한다.
3. SSG를 시도하면 pre-renderging 을 하려고하는데, 이때 nodejs 버전이 18버전이라 toSorted가 지원되지않아 에러가 발생한다.
4. 동적렌더링을 사용하면, 런타임시에 Babel, SWC와 같은 트랜스파일러를 통해서 자바스크립트 파일이 트랜스파일링 되는데 이때 낮은 버전도 호환될 수 있는 메소드로 바꿔서 적용해줌. 그래서 런타임에 에러가 발생하지 않음.

``` 
참고. next build process
next build
├── 1. Compile
│   ├── SWC/Babel을 통한 코드 트랜스파일링
│   └── TypeScript -> JavaScript 변환
│
├── 2. Build SSG Pages
│   ├── getStaticProps 실행
│   ├── 페이지 컴포넌트 실행
│   └── HTML 생성
│
└── 3. Output
    ├── .next/static/chunks/... (클라이언트 번들)
    └── .next/server/... (서버 번들)

--------------------------------------------------------------------

// 1단계: 코드 트랜스파일링
// ✅ 이 단계에서 코드는 트랜스파일링됨
const code = `
  const routes = await getShuttleRoutes();
  const sortedRoutes = toSortedRoutes('셔틀 일자 빠른 순', routes);
`;

// 2단계: 빌드 타임에 실제 코드 실행
// ❌ 하지만 이 실행은 트랜스파일된 코드가 아닌,
// Node.js 빌드 프로세스 환경에서 직접 실행됨

--------------------------------------------------------------------

핵심 차이점
// SSG (빌드 타임)
- 코드는 트랜스파일링되지만
- 실제 실행은 빌드 프로세스의 Node.js 환경에서 발생
- 따라서 toSorted를 지원하지 않는 Node.js 18에서 에러 발생

// 동적 렌더링 (런타임)
- 코드는 트랜스파일링됨
- 실행은 트랜스파일된 코드가 실행됨
- 따라서 Node.js 18에서도 정상 동작
```



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).