### PR TITLE
chore: remove build test in PR-CHECKER

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -13,19 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build project
-        run: npm run build || exit 1
-        env:
-          NEXT_PUBLIC_BASE_URL: ${{ secrets.NEXT_PUBLIC_BASE_URL }}
-          NEXT_PUBLIC_DOMAIN_URL: ${{ secrets.NEXT_PUBLIC_DOMAIN_URL }}
-          NEXT_PUBLIC_NEW_SHUTTLE_FORM_URL: ${{ secrets.NEXT_PUBLIC_NEW_SHUTTLE_FORM_URL }}
 
       - name: Debug Information
         run: |


### PR DESCRIPTION
## 개요

이전 vercel 을 사용하지 않을때 세팅해두었던 build test 를 제거합니다.
현재는 vercel 에서 빌드 테스트도 진행합니다.
이후 빌드 테스트가 제거되었기 때문에 PR-CHECKER의 검사 시간이 감소합니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).