### PR TITLE
fix: 예약 모집 중 캐러셀을 CSR로 변경

### DIFF
--- a/src/app/(home)/@reservation/page.tsx
+++ b/src/app/(home)/@reservation/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { ReactElement, ReactNode } from 'react';
 import Article from '@/components/article/Article';
 import { Region } from '@/hooks/useRegion';
@@ -10,34 +12,43 @@ import { getShuttleRoutes } from '@/services/shuttle-operation.service';
 import { ShuttleRoute } from '@/types/shuttle-operation.type';
 import { getUser } from '@/services/user-management.service';
 import { toSortedRoutes } from '@/app/reservation/util/sort.util';
+import { useQuery } from '@tanstack/react-query';
 
-const Page = async () => {
-  const { region, routes, promoted, userRegion } =
-    await getRegionAndOpenRoutes();
+const Page = () => {
+  const { data, isLoading } = useGetRegionAndOpenRoutes();
 
-  const location = promoted ? (
+  const location = data?.promoted ? (
     <p>
       <LocationMarker width="14" height="14" />
-      <b>{userRegion ? regionToString(userRegion) : '모든'}</b> 지역에 셔틀이
-      없어 <b>{region ? regionToString(region) : '모든'}</b> 지역의 셔틀을
-      보여드려요.
+      <b>{data?.userRegion ? regionToString(data?.userRegion) : '모든'}</b>{' '}
+      지역에 셔틀이 없어{' '}
+      <b>{data?.region ? regionToString(data?.region) : '모든'}</b> 지역의
+      셔틀을 보여드려요.
     </p>
   ) : (
     <p>
       <LocationMarker width="14" height="14" />
-      <b>{region ? regionToString(region) : '모든'}</b> 지역의 셔틀입니다.
+      <b>{data?.region ? regionToString(data?.region) : '모든'}</b> 지역의
+      셔틀입니다.
     </p>
   );
   const postfix = toSearchParams({
-    bigRegion: region?.bigRegion,
-    smallRegion: region?.smallRegion,
+    bigRegion: data?.region?.bigRegion,
+    smallRegion: data?.region?.smallRegion,
   }).toString();
 
-  const sortedRoutes = toSortedRoutes('셔틀 일자 빠른 순', routes).slice(0, 16);
+  const sortedRoutes = toSortedRoutes(
+    '셔틀 일자 빠른 순',
+    data?.routes ?? [],
+  ).slice(0, 16);
 
   return (
-    <Bar regionString={location} postfix={postfix}>
-      <RoutesSwiperView routes={sortedRoutes} />
+    <Bar regionString={location} postfix={postfix} isLoading={isLoading}>
+      {isLoading ? (
+        <div className="h-408" />
+      ) : (
+        <RoutesSwiperView routes={sortedRoutes} />
+      )}
     </Bar>
   );
 };
@@ -48,22 +59,32 @@ interface BarProp {
   postfix: string;
   regionString: ReactElement<HTMLParagraphElement>;
   children: ReactNode;
+  isLoading: boolean;
 }
 
-const Bar = ({ regionString, children, postfix }: BarProp) => {
+const Bar = ({ regionString, children, postfix, isLoading }: BarProp) => {
   return (
     <Article
       richTitle={`지금 예약 모집 중인 셔틀`}
       showMore={postfix === '' ? '/reservation' : `/reservation?${postfix}`}
     >
-      <div className="flex flex-row items-center gap-[2px] px-16 text-14 font-500 text-grey-600-sub">
-        <span className="[&>p>b]:font-600 [&>p>b]:text-primary-700 [&>p>svg]:inline [&>p>svg]:text-primary-700">
-          {regionString}
-        </span>
+      <div className="flex h-20 flex-row items-center gap-[2px] px-16 text-14 font-500 text-grey-600-sub">
+        {!isLoading && (
+          <span className="[&>p>b]:font-600 [&>p>b]:text-primary-700 [&>p>svg]:inline [&>p>svg]:text-primary-700">
+            {regionString}
+          </span>
+        )}
       </div>
       {children}
     </Article>
   );
+};
+
+const useGetRegionAndOpenRoutes = () => {
+  return useQuery({
+    queryKey: ['reservation', 'user-region'],
+    queryFn: getRegionAndOpenRoutes,
+  });
 };
 
 // 유저 지역과 관련된 노선을 가져오는 함수


### PR DESCRIPTION
## 개요

홈의 지금 예약 모집 중인 캐러셀을 SSR에서 CSR로 변경했습니다.

## 변경사항

토큰 저장 로직이 쿠키에서 로컬 스토리지로 변경되면서 기존에 서버사이드에서 유저 정보를 기반으로 필터 값을 주던 캐러셀의 로직이 동작하지 않게 되었습니다. 따라서 토큰 로직과 맞추어 클라이언트 사이드에서 동작하도록 변경했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).