### PR TITLE
fix: 예약 취소 바텀시트 높이 제한

### DIFF
--- a/src/app/mypage/shuttle/components/CancelBottomSheet.tsx
+++ b/src/app/mypage/shuttle/components/CancelBottomSheet.tsx
@@ -81,12 +81,14 @@ const CancelBottomSheet = ({
           </Step>
           <Step name="취소 수수료">
             <section>
-              <CancellationAndRefundContent />
-              {isRefundable && refundFee !== null && (
-                <article className="mt-16 bg-grey-50 p-8 text-center text-14 font-700 text-red-500">
-                  취소 수수료: {refundFee.toLocaleString()}원
-                </article>
-              )}
+              <div className="max-h-[55dvh] overflow-y-auto">
+                <CancellationAndRefundContent />
+                {isRefundable && refundFee !== null && (
+                  <article className="mt-16 bg-grey-50 p-8 text-center text-14 font-700 text-red-500">
+                    취소 수수료: {refundFee.toLocaleString()}원
+                  </article>
+                )}
+              </div>
               <div className="flex gap-8 py-16">
                 <Button
                   type="button"


### PR DESCRIPTION
## 개요

예약 취소 바텀시트의 약관 섹션에 높이 제한을 두어 하단 버튼이 안보이는 현상을 해결했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).