### PR TITLE
feat: 결제실패시 toss error message 핸들링

### DIFF
--- a/src/app/reservation/[id]/write/payments/fail/page.tsx
+++ b/src/app/reservation/[id]/write/payments/fail/page.tsx
@@ -5,11 +5,34 @@ import Link from 'next/link';
 interface Props {
   searchParams: {
     code?: string;
+    userExceptionMessage?: string;
   };
 }
-
 const Page = ({ searchParams }: Props) => {
   const code = Number(searchParams.code);
+
+  if (code === 402) {
+    const userExceptionMessage =
+      searchParams.userExceptionMessage || '알 수 없는 오류입니다.';
+    return (
+      <main className="flex grow flex-col items-center justify-center gap-24">
+        <LogoLargeIcon viewBox="0 0 121 75" width="90px" height="44px" />
+        <section>
+          <h1 className="flex justify-center text-28 font-700 leading-[39.2px] text-black">
+            결제 중 문제가 생겼습니다.
+          </h1>
+          <p className="flex justify-center text-16 font-500 leading-[25.6px] text-grey-500">
+            {userExceptionMessage}
+          </p>
+        </section>
+        <div className="fixed bottom-0 left-0 right-0 mx-auto max-w-500 p-16">
+          <Link href="/">
+            <Button>홈으로 돌아가기</Button>
+          </Link>
+        </div>
+      </main>
+    );
+  }
 
   if (code === 409) {
     return (

--- a/src/app/reservation/[id]/write/payments/page.tsx
+++ b/src/app/reservation/[id]/write/payments/page.tsx
@@ -31,7 +31,12 @@ const Page = () => {
     try {
       await setTimeoutWithRetry(() => polling(reservationId), 3, 3000);
     } catch {
-      router.replace(pathname + `/fail?code=${error?.statusCode}`);
+      if (error.statusCode === 402) {
+        router.replace(
+          pathname +
+            `/fail?code=${error?.statusCode}?userExceptionMessage=${error.message}`,
+        );
+      } else router.replace(pathname + `/fail?code=${error?.statusCode}`);
     }
   };
 


### PR DESCRIPTION
## 개요
결제 실패시 유저 측 사유로 발생하는 토스페이먼츠 실패 케이스를 핸들링하였습니다.
토스페이먼츠 에러 메세지를 보여줍니다.

#### 레이아웃
보여지는 페이지의 구성은 다음과 같습니다
- 큰제목 : 결제 중 문제가 생겼습니다.
- 설명 : 잔액이 부족합니다 등 토스페이먼츠 에러메세지

참고.
(1) 409 완료된 예약 결제의 경우
- 큰 제목 :       이미 완료된 예약결제입니다.
- 설명 :    내 예약 페이지에서 확인해주세요.

(2) 이외 다른 결제 실패 페이지 구성 
- 큰 제목 : 결제 중 문제가 생겼습니다.
- 설명 : 마이페이지에서 결제 내역을 확인한 후 다시 시도해주세요.



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).