### PR TITLE
fix: 소셜 로그인 시 정보가 오지 않는 경우 대응

### DIFF
--- a/src/app/mypage/profile/edit/components/EditForm.tsx
+++ b/src/app/mypage/profile/edit/components/EditForm.tsx
@@ -71,7 +71,7 @@ const EditForm = ({ type, user }: Props) => {
       key: 'users/profiles',
       file: formData.profileImage,
     });
-    if (!(formData.bigRegion && formData.smallRegion)) {
+    if (type === 'region' && !(formData.bigRegion && formData.smallRegion)) {
       methods.setError('bigRegion', {
         type: 'required',
         message: ERROR_MESSAGES.region.required,
@@ -79,8 +79,11 @@ const EditForm = ({ type, user }: Props) => {
       setIsSubmitting(false);
       return;
     }
-    const regionId = REGION_TO_ID[formData.bigRegion][formData.smallRegion];
-    if (!regionId) {
+    const regionId =
+      formData.bigRegion && formData.smallRegion
+        ? REGION_TO_ID[formData.bigRegion][formData.smallRegion]
+        : undefined;
+    if (type === 'region' && !regionId) {
       toast.error('프로필 수정에 실패하였습니다.');
       setIsSubmitting(false);
       return;

--- a/src/app/onboarding/components/OnboardingFunnel.tsx
+++ b/src/app/onboarding/components/OnboardingFunnel.tsx
@@ -1,17 +1,34 @@
 'use client';
 
-import { useEffect } from 'react';
+import useFunnel from '@/hooks/useFunnel';
+import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { KeyboardEvent, useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+import { OnboardingFormValues } from '@/components/onboarding-contents/onboarding.types';
 import { useRouter } from 'next/navigation';
+import { FORM_DEFAULT_VALUES } from '@/components/onboarding-contents/formValidation.constants';
 import AgreementStep from './steps/AgreementStep';
+import PersonalInfoStep from './steps/PersonalInfoStep';
+import { usePutUser } from '@/services/user-management.service';
+import { AgeRange, Gender, PutUserBody } from '@/types/user-management.type';
+import { setFirstSignup } from '@/utils/localStorage';
 import { setOnboardingStatusComplete } from '@/utils/handleToken.util';
+
+const ONBOARDING_STEPS = ['약관 동의', '개인 정보'] as const;
 
 interface Props {
   isOnboardingComplete: boolean;
+  isAgreementComplete: boolean;
+  initialGender: Exclude<Gender, 'NONE'> | null;
+  initialAgeRange: Exclude<AgeRange, '연령대 미지정'> | null;
 }
 
-const OnboardingFunnel = ({ isOnboardingComplete }: Props) => {
-  const router = useRouter();
-
+const OnboardingFunnel = ({
+  isOnboardingComplete,
+  isAgreementComplete,
+  initialGender,
+  initialAgeRange,
+}: Props) => {
   useEffect(() => {
     if (isOnboardingComplete) {
       setOnboardingStatusComplete();
@@ -19,7 +36,108 @@ const OnboardingFunnel = ({ isOnboardingComplete }: Props) => {
     }
   }, [isOnboardingComplete]);
 
-  return <AgreementStep />;
+  const initialStep: (typeof ONBOARDING_STEPS)[number] = isAgreementComplete
+    ? '개인 정보'
+    : '약관 동의';
+  const { Funnel, Step, handleNextStep, handlePrevStep } = useFunnel(
+    ONBOARDING_STEPS,
+    initialStep,
+  );
+
+  const methods = useForm<OnboardingFormValues>({
+    defaultValues: {
+      ...FORM_DEFAULT_VALUES,
+      gender:
+        initialGender === 'MALE'
+          ? '남성'
+          : initialGender === 'FEMALE'
+            ? '여성'
+            : undefined,
+      age: initialAgeRange ?? undefined,
+    },
+    mode: 'onBlur',
+  });
+
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { mutate: putUser, isSuccess } = usePutUser({
+    options: {
+      skipCheckOnboarding: true,
+    },
+    onSuccess: async () => {
+      setOnboardingStatusComplete();
+      setFirstSignup();
+      router.replace('/');
+    },
+    onError: (e) => {
+      console.error(e);
+      toast.error('회원가입에 실패하였습니다.');
+      setIsSubmitting(false);
+    },
+  });
+
+  const submitForm: SubmitHandler<OnboardingFormValues> = async (formData) => {
+    setIsSubmitting(true);
+    const body: PutUserBody = {
+      ageRange: formData.age,
+      gender:
+        formData.gender === '남성' ? ('MALE' as const) : ('FEMALE' as const),
+      isAgreedServiceTerms: isAgreementComplete
+        ? undefined
+        : formData.isAgreedServiceTerms,
+      isAgreedPersonalInfo: isAgreementComplete
+        ? undefined
+        : formData.isAgreedPersonalInfo,
+      isAgreedMarketing: isAgreementComplete
+        ? undefined
+        : formData.isAgreedMarketing,
+    };
+    putUser(body);
+  };
+  const triggerSubmitForm = () => {
+    const onboardingForm = document.getElementById(
+      'onboarding-form',
+    ) as HTMLFormElement;
+    onboardingForm?.requestSubmit();
+  };
+  const handleEnter = (e: KeyboardEvent<HTMLFormElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+    }
+  };
+
+  const disabled = isSubmitting || isSuccess;
+
+  return (
+    <FormProvider {...methods}>
+      <form
+        onSubmit={methods.handleSubmit(submitForm)}
+        onKeyDown={handleEnter}
+        noValidate
+        className="relative flex w-full grow flex-col"
+        id="onboarding-form"
+      >
+        <Funnel>
+          <Step name="약관 동의">
+            <AgreementStep
+              handleNextStep={handleNextStep}
+              triggerSubmitForm={triggerSubmitForm}
+              hasPersonalInfo={!!initialGender && !!initialAgeRange}
+              disabled={disabled}
+            />
+          </Step>
+          <Step name="개인 정보">
+            <PersonalInfoStep
+              handlePrevStep={handlePrevStep}
+              triggerSubmitForm={triggerSubmitForm}
+              disabled={disabled}
+              isAgreementComplete={isAgreementComplete}
+            />
+          </Step>
+        </Funnel>
+      </form>
+    </FormProvider>
+  );
 };
 
 export default OnboardingFunnel;

--- a/src/app/onboarding/components/steps/PersonalInfoStep.tsx
+++ b/src/app/onboarding/components/steps/PersonalInfoStep.tsx
@@ -6,26 +6,33 @@ import PersonalInfoContent from '@/components/onboarding-contents/PersonalInfoCo
 import { useFormContext } from 'react-hook-form';
 
 interface Props {
-  handleNextStep: () => void;
   handlePrevStep: () => void;
+  triggerSubmitForm: () => void;
+  disabled: boolean;
+  isAgreementComplete: boolean;
 }
 
-const PersonalInfoStep = ({ handleNextStep, handlePrevStep }: Props) => {
+const PersonalInfoStep = ({
+  handlePrevStep,
+  triggerSubmitForm,
+  disabled,
+  isAgreementComplete,
+}: Props) => {
   const { trigger } = useFormContext<OnboardingFormValues>();
 
   const handleCheckStep = async () => {
     const isStepValid = await trigger(['gender', 'age']);
     if (isStepValid) {
-      handleNextStep();
+      triggerSubmitForm();
     }
   };
 
   return (
     <OnboardingFrame
       handleSubmit={handleCheckStep}
-      handlePrevStep={handlePrevStep}
-      indicatorMax={4}
-      indicatorValue={3}
+      handlePrevStep={isAgreementComplete ? handlePrevStep : undefined}
+      buttonText="핸디버스 만나러 가기"
+      disabled={disabled}
     >
       <PersonalInfoContent />
     </OnboardingFrame>

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -7,15 +7,34 @@ import Loading from '@/components/loading/Loading';
 
 const Page = () => {
   const { data: user, isLoading } = useGetUser({ skipCheckOnboarding: true });
+
   const isOnboardingComplete =
     user?.progresses?.find((el) => el.progressType === 'ONBOARDING_COMPLETE')
       ?.isCompleted || false;
+
+  const isAgreementComplete =
+    (user?.progresses?.find((el) => el.progressType === 'PERSONAL_INFO_CONSENT')
+      ?.isCompleted &&
+      user?.progresses?.find(
+        (el) => el.progressType === 'SERVICE_TERMS_AGREEMENT',
+      )?.isCompleted) ||
+    false;
+
+  const initialGender =
+    user?.gender && user?.gender !== 'NONE' ? user.gender : null;
+  const initialAgeRange =
+    user?.ageRange && user?.ageRange !== '연령대 미지정' ? user.ageRange : null;
 
   return (
     <div className="relative flex h-full w-full grow flex-col pt-36">
       <DeferredSuspense fallback={<Loading />} isLoading={isLoading}>
         {user && (
-          <OnboardingFunnel isOnboardingComplete={isOnboardingComplete} />
+          <OnboardingFunnel
+            isOnboardingComplete={isOnboardingComplete}
+            isAgreementComplete={isAgreementComplete}
+            initialGender={initialGender}
+            initialAgeRange={initialAgeRange}
+          />
         )}
       </DeferredSuspense>
     </div>

--- a/src/components/onboarding-contents/PersonalInfoContent.tsx
+++ b/src/components/onboarding-contents/PersonalInfoContent.tsx
@@ -5,7 +5,6 @@ import { OnboardingFormValues } from './onboarding.types';
 import RadioButtons from '../buttons/radio-buttons/RadioButtons';
 import { ERROR_MESSAGES } from './formValidation.constants';
 import OnboardingTitle from './OnboardingTitle';
-import { useEffect, useState } from 'react';
 
 const GENDER_OPTIONS = ['여성', '남성'] as const;
 const AGE_OPTIONS = [
@@ -20,25 +19,11 @@ const AGE_OPTIONS = [
 ] as const;
 
 const PersonalInfoContent = () => {
-  const { control, setValue, getValues } =
-    useFormContext<OnboardingFormValues>();
-
-  const [nickname, setNickname] = useState<string | undefined>(undefined);
-  useEffect(() => {
-    setNickname(getValues('nickname'));
-  }, []);
+  const { control, setValue } = useFormContext<OnboardingFormValues>();
 
   return (
     <>
-      <OnboardingTitle
-        title={
-          <>
-            <span className="text-primary-main">{nickname}</span>님의
-            <br />
-            성별과 연령대를 알려주세요
-          </>
-        }
-      />
+      <OnboardingTitle title="성별과 연령대를 알려주세요" />
       <div className="w-full px-28">
         <div className="mb-16 text-16 font-500 text-grey-600-sub">
           성별을 선택해주세요

--- a/src/components/onboarding-contents/formValidation.constants.ts
+++ b/src/components/onboarding-contents/formValidation.constants.ts
@@ -27,4 +27,7 @@ export const FORM_DEFAULT_VALUES = {
   bigRegion: undefined,
   smallRegion: undefined,
   favoriteArtists: [],
+  isAgreedServiceTerms: false,
+  isAgreedPersonalInfo: false,
+  isAgreedMarketing: false,
 };

--- a/src/components/onboarding-contents/onboarding.types.ts
+++ b/src/components/onboarding-contents/onboarding.types.ts
@@ -12,4 +12,7 @@ export interface OnboardingFormValues {
   smallRegion: string | undefined;
   regionId: string | null;
   favoriteArtists: Artist[];
+  isAgreedMarketing: boolean;
+  isAgreedServiceTerms: boolean;
+  isAgreedPersonalInfo: boolean;
 }


### PR DESCRIPTION
## 개요

소셜 계정에서 성별 및 연령대 정보가 주어지지 않는 경우 온보딩 단계에서 정보를 수집할 수 있도록 수정했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).