### PR TITLE
fix: 예약 상세 페이지의 지도 위치 수정

### DIFF
--- a/src/app/reservation/[id]/page.tsx
+++ b/src/app/reservation/[id]/page.tsx
@@ -33,15 +33,9 @@ const Page = async ({ params, searchParams }: Props) => {
         <EventImage image={shuttleRoute.event.eventImageUrl} />
         <RouteInfo route={shuttleRoute} />
         <KakaoMap
-          placeName={
-            shuttleRoute.toDestinationShuttleRouteHubs?.[0]?.name ?? ''
-          }
-          latitude={
-            shuttleRoute.toDestinationShuttleRouteHubs?.[0]?.latitude ?? 0
-          }
-          longitude={
-            shuttleRoute.toDestinationShuttleRouteHubs?.[0]?.longitude ?? 0
-          }
+          placeName={shuttleRoute.event.eventLocationName}
+          latitude={shuttleRoute.event.eventLocationLatitude}
+          longitude={shuttleRoute.event.eventLocationLongitude}
         />
         <ReservationForm
           event={shuttleRoute.event}


### PR DESCRIPTION
## 개요

예약 상세 페이지에서 지도의 위치가 잘못 들어가던 문제를 행사장으로 올바르게 변경했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).