### PR TITLE
fix: 갱신된 토큰을 retry 요청에서 사용하도록 수정

### DIFF
--- a/src/types/user-management.type.ts
+++ b/src/types/user-management.type.ts
@@ -214,6 +214,8 @@ export const UserSchema = z
     marketingConsent: z.boolean(),
     serviceTermsAgreement: z.boolean(),
     personalInfoConsent: z.boolean(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
   })
   .strict();
 export type User = z.infer<typeof UserSchema>;


### PR DESCRIPTION
## 개요

토큰 갱신 로직에서 갱신 이후 retry 하는 api의 토큰을 갱신된 토큰을 사용하도록 변경했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).