### PR TITLE
chore: release 예외처리

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -45,7 +45,7 @@ jobs:
             revert
             release
           requireScope: false
-          subjectPattern: ^([A-Za-z가-힣].+|release)$
+          subjectPattern: ^(([A-Za-z가-힣].+)|release)$
           subjectPatternError: |
             The subject must start with a letter or a Korean character and not end with a period.
           wip: false


### PR DESCRIPTION
## 개요 (테스트필요)
git action인 PR_CHECKER에서 release 만 사용해도 허용할 수 있게 합니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).