### PR TITLE
chore: ignore label about release

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -45,8 +45,10 @@ jobs:
             revert
             release
           requireScope: false
-          subjectPattern: ^(([A-Za-z가-힣].+)|release)$
+          subjectPattern: ^([A-Za-z가-힣].+)$
           subjectPatternError: |
             The subject must start with a letter or a Korean character and not end with a period.
           wip: false
           validateSingleCommit: false
+          ignoreLabels:
+            - 'release'


### PR DESCRIPTION
## 개요
release label을 단 pr의 경우 checker가 사용하는 `action-semantic-pull-request@v5`를 무시하는 방법으로 시도해봅니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).