### PR TITLE
feat: 왕복행만 핸디를 선택할 수 있게 변경

### DIFF
--- a/src/app/reservation/[id]/write/components/steps/payment-step/ApplyHandy.tsx
+++ b/src/app/reservation/[id]/write/components/steps/payment-step/ApplyHandy.tsx
@@ -5,8 +5,9 @@ import HandyRequestModal from '@/components/modals/handy-request/HandyRequestMod
 import { useState } from 'react';
 
 const ApplyHandy = () => {
-  const { control } = useFormContext<ReservationFormValues>();
+  const { control, getValues } = useFormContext<ReservationFormValues>();
   const [isHandyRequestModalOpen, setIsHandyRequestModalOpen] = useState(false);
+  const isRoundTrip = getValues('type') === 'ROUND_TRIP';
 
   return (
     <>
@@ -14,7 +15,9 @@ const ApplyHandy = () => {
         <div>
           <h3 className="text-22 font-700 text-grey-900">핸디 지원하기</h3>
           <p className="text-14 font-400 text-grey-500">
-            핸디는 50% 셔틀비를 지원받을 수 있어요!
+            {isRoundTrip
+              ? '핸디는 50% 셔틀비를 지원받을 수 있어요!'
+              : '아쉽게도 핸디는 왕복 셔틀만 지원이 가능해요.'}
           </p>
         </div>
         <div className="flex gap-8">
@@ -30,6 +33,7 @@ const ApplyHandy = () => {
                   onClick={() => {
                     onChange(false);
                   }}
+                  disabled={!isRoundTrip}
                 >
                   안 할래요
                 </Button>
@@ -44,6 +48,7 @@ const ApplyHandy = () => {
                   onClick={() => {
                     onChange(true);
                   }}
+                  disabled={!isRoundTrip}
                 >
                   지원 할래요
                 </Button>


### PR DESCRIPTION
## 개요
- 결제 페이지에서 왕복을 선택해야만 핸디를 선택할 수 있습니다.

https://github.com/user-attachments/assets/7c30e186-f89b-4c7a-af89-aea98802428b



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).