### PR TITLE
fix: 왕복 잔여석이 존재 시 추가 셔틀 요청하기 버튼 숨김 처리

### DIFF
--- a/src/app/reservation/[id]/write/components/steps/RouteSelectStep.tsx
+++ b/src/app/reservation/[id]/write/components/steps/RouteSelectStep.tsx
@@ -267,7 +267,7 @@ const TypeSelect = () => {
                 <button
                   onClick={handleShuttleRouteDemandClick}
                   type="button"
-                  className="flex w-full items-center justify-center border-t border-grey-100 py-12 text-14 font-600 text-[#5A5A5A]"
+                  className="flex w-full items-center justify-center border-t border-[#F3F3F3] py-[14px] text-14 font-600 text-[#5A5A5A]"
                 >
                   추가 셔틀 요청하기
                 </button>

--- a/src/app/reservation/[id]/write/components/steps/RouteSelectStep.tsx
+++ b/src/app/reservation/[id]/write/components/steps/RouteSelectStep.tsx
@@ -231,6 +231,9 @@ const TypeSelect = () => {
     });
   };
 
+  const showShuttleRouteDemandButton =
+    watchedShuttleRoute && getRemainingSeatCount('ROUND_TRIP') === 0;
+
   return (
     <Controller
       control={control}
@@ -260,13 +263,15 @@ const TypeSelect = () => {
               </p>
             )}
             extraContent={
-              <button
-                onClick={handleShuttleRouteDemandClick}
-                type="button"
-                className="-mx-32 flex w-[calc(100%+64px)] items-center justify-center border-t border-grey-100 py-[10px] text-14 font-600 text-[#5A5A5A]"
-              >
-                추가 셔틀 요청하기
-              </button>
+              showShuttleRouteDemandButton ? (
+                <button
+                  onClick={handleShuttleRouteDemandClick}
+                  type="button"
+                  className="flex w-full items-center justify-center border-t border-grey-100 py-12 text-14 font-600 text-[#5A5A5A]"
+                >
+                  추가 셔틀 요청하기
+                </button>
+              ) : null
             }
             sort
             disabled={!watchedShuttleRoute}

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -78,7 +78,7 @@ const Select = <T,>({
       <BottomSheet ref={bottomSheetRef} title={bottomSheetTitle}>
         <div
           ref={contentRef}
-          className="h-full w-full overflow-y-auto bg-white"
+          className="relative h-full w-full overflow-y-auto overflow-x-hidden bg-white"
         >
           <section className="flex flex-col">
             {sortedOptions?.length === 0 ? (


### PR DESCRIPTION
## 개요

가는 편과 오는 편의 잔여석이 모두 존재하는 상태에는 추가 셔틀 요청하기 버튼이 숨김 처리 되도록 수정했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).