### PR TITLE
feat: 홈페이지 전체보기 개선

### DIFF
--- a/src/app/(home)/@bot/components/Overviews.tsx
+++ b/src/app/(home)/@bot/components/Overviews.tsx
@@ -18,7 +18,7 @@ const Overviews = () => {
   };
 
   return (
-    <Article richTitle="핸디버스를 더 자세하게" titleSize="text-20">
+    <Article richTitle="핸디버스를 더 자세하게" titleClassName="text-20">
       <div className="px-16 py-[10px]">
         <Tabs
           items={[

--- a/src/app/(home)/@bot/components/Overviews.tsx
+++ b/src/app/(home)/@bot/components/Overviews.tsx
@@ -18,7 +18,7 @@ const Overviews = () => {
   };
 
   return (
-    <Article richTitle="핸디버스를 더 자세하게">
+    <Article richTitle="핸디버스를 더 자세하게" titleSize="text-20">
       <div className="px-16 py-[10px]">
         <Tabs
           items={[

--- a/src/app/(home)/@bot/components/PromotionReviews.tsx
+++ b/src/app/(home)/@bot/components/PromotionReviews.tsx
@@ -20,7 +20,7 @@ const PromotionReview = async () => {
   return (
     <Article
       richTitle="핸디버스의 생생한 후기"
-      titleSize="text-20"
+      titleClassName="text-20"
       showMore="/help/reviews"
     >
       {top3.map((review) => (

--- a/src/app/(home)/@bot/components/PromotionReviews.tsx
+++ b/src/app/(home)/@bot/components/PromotionReviews.tsx
@@ -18,7 +18,11 @@ const PromotionReview = async () => {
     .slice(0, 3);
 
   return (
-    <Article richTitle="핸디버스의 생생한 후기" showMore="/help/reviews">
+    <Article
+      richTitle="핸디버스의 생생한 후기"
+      titleSize="text-20"
+      showMore="/help/reviews"
+    >
       {top3.map((review) => (
         <div
           key={review.reviewId}

--- a/src/app/(home)/@demand/components/DemandView.tsx
+++ b/src/app/(home)/@demand/components/DemandView.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const DemandView = ({ event }: Props) => {
   return (
-    <Link href={`/demand/${event.eventId}`} className="px-16 py-12">
+    <Link href={`/demand/${event.eventId}`} className="px-16 py-8">
       <article className="flex flex-row gap-16">
         <figure className="relative min-h-[110px] min-w-[80px] overflow-hidden rounded-[8px] bg-grey-300">
           <Image

--- a/src/app/(home)/@demand/page.tsx
+++ b/src/app/(home)/@demand/page.tsx
@@ -3,8 +3,8 @@ import DemandView from './components/DemandView';
 import dynamic from 'next/dynamic';
 import { getEvents } from '@/services/event.service';
 import { toSorted } from '@/app/demand/utils/toSorted.util';
-import Button from '@/components/buttons/button/Button';
 import ChevronRightEm from 'public/icons/chevron-right-em.svg';
+import Link from 'next/link';
 const Empty = dynamic(() => import('@/app/demand/components/Empty'));
 
 const Page = () => (
@@ -17,13 +17,13 @@ const Page = () => (
       <SubPage />
     </Article>
     <div className="px-16">
-      <Button
-        className="text-16 font-500 leading-[25.6px] "
-        variant="secondary"
+      <Link
+        href="/demand"
+        className="flex h-44 w-full flex-row items-center justify-center gap-[2px] whitespace-nowrap rounded-full bg-grey-50 p-12 py-8 text-center text-16 font-500 leading-[25.6px] text-grey-700 active:bg-grey-100 "
       >
         모든 수요조사 보기
         <ChevronRightEm className="h-16 w-16 stroke-2" />
-      </Button>
+      </Link>
     </div>
   </section>
 );

--- a/src/app/(home)/@demand/page.tsx
+++ b/src/app/(home)/@demand/page.tsx
@@ -11,20 +11,18 @@ const Page = () => (
   <section className="flex flex-col gap-12">
     <Article
       richTitle="수요조사 진행 중"
-      titleSize="text-20"
+      titleClassName="text-20"
       showMore="/demand"
     >
       <SubPage />
     </Article>
-    <div className="px-16">
-      <Link
-        href="/demand"
-        className="flex h-44 w-full flex-row items-center justify-center gap-[2px] whitespace-nowrap rounded-full bg-grey-50 p-12 py-8 text-center text-16 font-500 leading-[25.6px] text-grey-700 active:bg-grey-100 "
-      >
-        모든 수요조사 보기
-        <ChevronRightEm className="h-16 w-16 stroke-2" />
-      </Link>
-    </div>
+    <Link
+      href="/demand"
+      className="mx-[16px] flex h-44 w-[calc(100%-32px)] flex-row items-center justify-center gap-[2px] whitespace-nowrap rounded-full bg-grey-50 p-12 py-8 text-center text-16 font-500 leading-[25.6px] text-grey-700 active:bg-grey-100 "
+    >
+      모든 수요조사 보기
+      <ChevronRightEm className="h-16 w-16 stroke-2" />
+    </Link>
   </section>
 );
 

--- a/src/app/(home)/@demand/page.tsx
+++ b/src/app/(home)/@demand/page.tsx
@@ -3,12 +3,29 @@ import DemandView from './components/DemandView';
 import dynamic from 'next/dynamic';
 import { getEvents } from '@/services/event.service';
 import { toSorted } from '@/app/demand/utils/toSorted.util';
+import Button from '@/components/buttons/button/Button';
+import ChevronRightEm from 'public/icons/chevron-right-em.svg';
 const Empty = dynamic(() => import('@/app/demand/components/Empty'));
 
 const Page = () => (
-  <Article richTitle="수요조사 진행 중" showMore="/demand">
-    <SubPage />
-  </Article>
+  <section className="flex flex-col gap-12">
+    <Article
+      richTitle="수요조사 진행 중"
+      titleSize="text-20"
+      showMore="/demand"
+    >
+      <SubPage />
+    </Article>
+    <div className="px-16">
+      <Button
+        className="text-16 font-500 leading-[25.6px] "
+        variant="secondary"
+      >
+        모든 수요조사 보기
+        <ChevronRightEm className="h-16 w-16 stroke-2" />
+      </Button>
+    </div>
+  </section>
 );
 
 export default Page;

--- a/src/app/(home)/@reservation/page.tsx
+++ b/src/app/(home)/@reservation/page.tsx
@@ -18,7 +18,7 @@ const Page = () => {
   return (
     <Article
       richTitle={`예약 가능한 셔틀`}
-      titleSize="text-20"
+      titleClassName="text-20"
       showMore="/reservation"
     >
       {isLoading ? (

--- a/src/app/(home)/@reservation/page.tsx
+++ b/src/app/(home)/@reservation/page.tsx
@@ -16,7 +16,11 @@ const Page = () => {
   );
 
   return (
-    <Article richTitle={`예약 가능한 셔틀`} showMore="/reservation">
+    <Article
+      richTitle={`예약 가능한 셔틀`}
+      titleSize="text-20"
+      showMore="/reservation"
+    >
       {isLoading ? (
         <div className="h-408" />
       ) : (

--- a/src/app/help/about/components/AboutMerit.tsx
+++ b/src/app/help/about/components/AboutMerit.tsx
@@ -2,7 +2,7 @@ import Article from '@/components/article/Article';
 import { PropsWithChildren } from 'react';
 
 const AboutMerit = () => (
-  <Article richTitle="이런 점이 좋아요" titleSize="small" className="w-full">
+  <Article richTitle="이런 점이 좋아요" className="w-full">
     <div className="mx-16 mt-28 flex flex-col gap-16 border-l-2 border-l-grey-50 pl-12 pt-12 text-grey-900">
       <ul className="flex list-none flex-col gap-16">
         <MeritItem text="환승 없이 행사장까지 바로 이동해요.">

--- a/src/app/help/about/components/AboutService.tsx
+++ b/src/app/help/about/components/AboutService.tsx
@@ -9,7 +9,6 @@ import Person3 from '../images/person3.png';
 const AboutService = () => (
   <Article
     richTitle="이런 고민 해본 적 있나요?"
-    titleSize="small"
     className="flex w-full flex-col gap-[26px]"
   >
     <div className="flex w-full flex-col px-36">

--- a/src/app/help/about/components/AboutStats.tsx
+++ b/src/app/help/about/components/AboutStats.tsx
@@ -5,7 +5,6 @@ import HandyTransparent from '../images/handy-transparent.png';
 const AboutStats = () => (
   <Article
     richTitle="지금까지 핸디버스는"
-    titleSize="small"
     className="flex flex-col items-center"
   >
     <div className="mt-28 flex h-[152px] flex-col items-center justify-start rounded-[12px] px-[13px] py-[14px] shadow-md">

--- a/src/app/help/faq/page.tsx
+++ b/src/app/help/faq/page.tsx
@@ -24,7 +24,7 @@ const FAQPage = async () => (
           </p>
         </div>
       }
-      titleSize="text-28"
+      titleClassName="text-28"
       className="mb-28 flex flex-col gap-24"
     >
       <div>

--- a/src/app/help/faq/page.tsx
+++ b/src/app/help/faq/page.tsx
@@ -24,7 +24,7 @@ const FAQPage = async () => (
           </p>
         </div>
       }
-      titleSize="large"
+      titleSize="text-28"
       className="mb-28 flex flex-col gap-24"
     >
       <div>

--- a/src/app/help/how-to/page.tsx
+++ b/src/app/help/how-to/page.tsx
@@ -27,7 +27,7 @@ const HowToPage = () => {
           />
         </figure>
       </article>
-      <Article richTitle="1. 수요조사" titleSize="small">
+      <Article richTitle="1. 수요조사">
         <p className="ml-36 text-16 font-500 leading-[26px] text-grey-900">
           여러분의 관심도를 체크해요
         </p>
@@ -54,7 +54,7 @@ const HowToPage = () => {
           </li>
         </ul>
       </Article>
-      <Article richTitle="2. 운행 확정" titleSize="small">
+      <Article richTitle="2. 운행 확정">
         <p className="ml-36 text-16 font-500 leading-[26px] text-grey-900">
           노선 운행을 결정해요
         </p>
@@ -66,7 +66,7 @@ const HowToPage = () => {
           </li>
         </ul>
       </Article>
-      <Article richTitle="3. 셔틀 예약" titleSize="small" className="pb-28">
+      <Article richTitle="3. 셔틀 예약" className="pb-28">
         <p className="ml-36 text-16 font-500 leading-[26px] text-grey-900">
           30초만에 간편하게 예약하세요
         </p>

--- a/src/components/article/Article.tsx
+++ b/src/components/article/Article.tsx
@@ -5,19 +5,23 @@ import Link from 'next/link';
 interface Props extends HTMLProps<HTMLDivElement> {
   richTitle: ReactNode;
   showMore?: string | UrlObject;
-  titleSize?: string;
+  titleClassName?: string;
 }
 
 const Article = ({
   children,
   richTitle,
-  titleSize = 'text-22',
+  titleClassName = 'text-22',
   showMore,
   ...props
 }: Props) => {
   return (
     <article {...props}>
-      <Title title={richTitle} titleSize={titleSize} showMore={showMore} />
+      <Title
+        title={richTitle}
+        titleClassName={titleClassName}
+        showMore={showMore}
+      />
       {children}
     </article>
   );
@@ -26,17 +30,18 @@ const Article = ({
 export default Article;
 
 import ChevronRightEm from 'public/icons/chevron-right-em.svg';
+import { twMerge } from 'tailwind-merge';
 
 interface TitleProps {
   title: ReactNode;
-  titleSize: string;
+  titleClassName: string;
   showMore?: string | UrlObject;
 }
 
-const Title = ({ title, titleSize, showMore }: TitleProps) => {
+const Title = ({ title, titleClassName, showMore }: TitleProps) => {
   return (
     <header className="flex w-full flex-row justify-between px-16 pb-4 pt-60">
-      <h2 className={`${titleSize} font-700`}>{title}</h2>
+      <h2 className={twMerge(titleClassName, 'font-700')}>{title}</h2>
       {showMore && (
         <Link href={showMore}>
           <span className="inline-flex cursor-pointer items-center gap-[2px] break-keep text-14 font-400 text-grey-600-sub">

--- a/src/components/article/Article.tsx
+++ b/src/components/article/Article.tsx
@@ -5,13 +5,13 @@ import Link from 'next/link';
 interface Props extends HTMLProps<HTMLDivElement> {
   richTitle: ReactNode;
   showMore?: string | UrlObject;
-  titleSize?: 'small' | 'large';
+  titleSize?: string;
 }
 
 const Article = ({
   children,
   richTitle,
-  titleSize = 'small',
+  titleSize = 'text-22',
   showMore,
   ...props
 }: Props) => {
@@ -29,18 +29,14 @@ import ChevronRightEm from 'public/icons/chevron-right-em.svg';
 
 interface TitleProps {
   title: ReactNode;
-  titleSize: 'small' | 'large';
+  titleSize: string;
   showMore?: string | UrlObject;
 }
 
 const Title = ({ title, titleSize, showMore }: TitleProps) => {
   return (
     <header className="flex w-full flex-row justify-between px-16 pb-4 pt-60">
-      <h2
-        className={`${titleSize === 'small' ? 'text-22' : 'text-28'} font-700`}
-      >
-        {title}
-      </h2>
+      <h2 className={`${titleSize} font-700`}>{title}</h2>
       {showMore && (
         <Link href={showMore}>
           <span className="inline-flex cursor-pointer items-center gap-[2px] break-keep text-12 font-400 text-grey-600-sub">

--- a/src/components/article/Article.tsx
+++ b/src/components/article/Article.tsx
@@ -39,10 +39,10 @@ const Title = ({ title, titleSize, showMore }: TitleProps) => {
       <h2 className={`${titleSize} font-700`}>{title}</h2>
       {showMore && (
         <Link href={showMore}>
-          <span className="inline-flex cursor-pointer items-center gap-[2px] break-keep text-12 font-400 text-grey-600-sub">
+          <span className="inline-flex cursor-pointer items-center gap-[2px] break-keep text-14 font-400 text-grey-600-sub">
             전체보기
             <span className="inline-block stroke-1">
-              <ChevronRightEm />
+              <ChevronRightEm className="h-16 w-16" />
             </span>
           </span>
         </Link>


### PR DESCRIPTION
## 개요
- 전체보기 버튼의 크기를 키워 가독성이 개선됩니다.
- 수요조사 캐러셀의 하단에 전체보기로 리디렉트하는 버튼을 배치하였습니다.
- 헤딩의 크기가 조정되었습니다.

#### Article
- titleSize Prop 은 small | large -> string으로 변경되었습니다. Article을 사용하는 부분에서 전부 반영완료


<img width="377" alt="Screenshot 2025-03-13 at 3 18 56 PM" src="https://github.com/user-attachments/assets/2a275d82-f283-4a80-9a69-5a08eaa580ee" />
<img width="398" alt="Screenshot 2025-03-13 at 3 19 00 PM" src="https://github.com/user-attachments/assets/e944af63-4c27-48a6-adb4-37e56501affb" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).