### PR TITLE
feat: 마이페이지에서 핸디 지원 불가 처리 

### DIFF
--- a/src/app/mypage/shuttle/[id]/components/sections/HandySection.tsx
+++ b/src/app/mypage/shuttle/[id]/components/sections/HandySection.tsx
@@ -8,14 +8,12 @@ import { usePostUpdateReservation } from '@/services/reservation.service';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
-const TEXT: Record<
-  HandyStatus,
-  {
-    title: string;
-    description: string | ((name: string) => string);
-    button: string;
-  }
-> = {
+const TEXT = {
+  NOT_QUALIFIED: {
+    title: '핸디 지원불가',
+    description: '아쉽게도 핸디는 왕복 셔틀만 지원이 가능해요.',
+    button: '',
+  },
   NOT_SUPPORTED: {
     title: '핸디 지원',
     description: '핸디는 신청자만 지원이 가능합니다.',
@@ -39,12 +37,12 @@ const TEXT: Record<
       '아쉽게도 핸디에 선정되지 않았어요. 다음 기회에 꼭 핸디로 함께 해요!',
     button: '',
   },
-};
+} as const;
 
 interface Props {
   reservationId: string;
   name: string;
-  handyStatus: HandyStatus;
+  handyStatus: HandyStatus | 'NOT_QUALIFIED';
 }
 
 const HandySection = ({ reservationId, name, handyStatus }: Props) => {
@@ -113,7 +111,7 @@ const HandySection = ({ reservationId, name, handyStatus }: Props) => {
             ? TEXT[handyStatus].description(name)
             : TEXT[handyStatus].description}
         </p>
-        {handyStatus !== 'DECLINED' && (
+        {handyStatus !== 'DECLINED' && handyStatus !== 'NOT_QUALIFIED' && (
           <Button type="button" onClick={handleButtonClick} className="mt-16">
             {TEXT[handyStatus].button}
           </Button>

--- a/src/app/mypage/shuttle/[id]/page.tsx
+++ b/src/app/mypage/shuttle/[id]/page.tsx
@@ -42,6 +42,16 @@ const ShuttleDetail = ({ params }: Props) => {
       dailyEvent.dailyEventId === data?.reservation?.shuttleRoute.dailyEventId,
   )?.date;
   const parsedDate = date ? dayjs(date).tz() : null;
+  const handyStatusWithNotQualified = () => {
+    if (
+      data?.reservation.handyStatus === 'NOT_SUPPORTED' &&
+      data?.reservation.type !== 'ROUND_TRIP'
+    ) {
+      return 'NOT_QUALIFIED';
+    }
+
+    return data?.reservation.handyStatus;
+  };
 
   if (isSuccess && !data) {
     router.replace('/mypage/shuttle?type=current');
@@ -78,7 +88,10 @@ const ShuttleDetail = ({ params }: Props) => {
                 <HandySection
                   reservationId={data.reservation.reservationId}
                   name={data.reservation.userNickname ?? ''}
-                  handyStatus={data.reservation.handyStatus}
+                  handyStatus={
+                    handyStatusWithNotQualified() ??
+                    data.reservation.handyStatus
+                  }
                 />
                 <RouteSection
                   reservationId={data.reservation.reservationId}
@@ -128,7 +141,6 @@ const ShuttleDetail = ({ params }: Props) => {
                 <ReservationInfoSection
                   reservation={data.reservation}
                   isExpandable
-                  hideApplyHandy={true}
                 />
                 <RefundGuideSection />
               </>


### PR DESCRIPTION
## 개요
왕복편을 선택하지 않은 예약건에 대해서 마이페이지에서 핸디지원이 불가능하도록 반영하였습니다.

## 변경사항
- handyStatus 가 NOT_SUPPORTED 일때 ROUND_TRIP이 아니라면 NOT_QUALIFIED 라는 상태를 <HandySection /> 에 props로 넘겨줍니다.
  - ROUND_TRIP이 아니라면 handyStatus와 상관없이 막아버릴 수도 있지만, 이미 편도행인데 핸디지원을 하셨던 유저분들도 존재하기도 하고, 기존의 유저들에게 영향을 주지 않고도 앞으로 편도행을 선택한 사람들에게만 핸디지원을 막아버릴 수 있는 방법을 사용했습니다.

<img width="387" alt="Screenshot 2025-03-21 at 1 16 39 PM" src="https://github.com/user-attachments/assets/65f70592-f770-4afc-bc2e-06b33e4219f1" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
  - handyStatus, type(왕복/가는편/오는편) 에 따라 각각 기능 테스트를 모두 마쳤습니다.