### PR TITLE
fix: 로그인 되었을 때에만 헤더에서 유저 정보를 불러오도록 수정

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -10,7 +10,9 @@ import { useGetUser } from '@/services/user.service';
 
 const Header = () => {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
-  const { data: user } = useGetUser();
+  const { data: user } = useGetUser({
+    enabled: isLoggedIn !== null && isLoggedIn,
+  });
   const profileImage = user?.profileImage;
   const nickname = user?.nickname;
 
@@ -25,7 +27,7 @@ const Header = () => {
       <Link href="/">
         <LogoIcon />
       </Link>
-      {isLoggedIn != null &&
+      {isLoggedIn !== null &&
         (isLoggedIn ? (
           <Link href="/mypage">
             <UserProfile nickname={nickname} profileImage={profileImage} />


### PR DESCRIPTION
## 개요

기존에 헤더에서 유저 정보를 무조건적으로 불러오기에 비로그인 상태로 헤더가 존재하는 페이지에 접속 시 홈으로 리다이렉트 되는 이슈가 있었습니다.
로그인 상태에서만 유저 정보를 불러오도록 수정하여 해결했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).