### PR TITLE
hotfix: login page coupon amount

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -56,7 +56,7 @@ const Login = () => {
       </section>
       <section className="p-16">
         <p className="mb-16 text-center text-16 font-600 text-[#181F29]">
-          지금 가입하면 <span className="text-primary-main">1만원</span> 쿠폰
+          지금 가입하면 <span className="text-primary-main">3천원</span> 쿠폰
           즉시 제공!
         </p>
         <button


### PR DESCRIPTION
## 개요
로그인 페이지에서 1만원 -> 3천원 쿠폰으로 수정

## 변경사항
#### 변경 전
<img width="465" alt="Screenshot 2025-04-22 at 1 13 47 PM" src="https://github.com/user-attachments/assets/69195ff9-daa9-4742-a15f-521ebd6f9783" />

#### 변경 후
<img width="365" alt="Screenshot 2025-04-22 at 1 14 43 PM" src="https://github.com/user-attachments/assets/1f114e32-f39a-4429-a315-324bc94e5dfe" />



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).