### PR TITLE
fix: 캐러셀 카드 extend 로직 수정

### DIFF
--- a/src/app/(home)/@event/components/EventsSwiperView.tsx
+++ b/src/app/(home)/@event/components/EventsSwiperView.tsx
@@ -9,6 +9,8 @@ import ViewAllButton from '@/app/(home)/@event/components/ViewAllButton';
 import Link from 'next/link';
 import { EventWithRoutesViewEntity } from '@/types/event.type';
 
+const MIN_CARD_COUNT = 5;
+
 interface Props {
   events: EventWithRoutesViewEntity[];
   type: 'TREND' | 'RECOMMEND';
@@ -18,7 +20,8 @@ const EventsSwiperView = ({ events, type }: Props) => {
   const swiper = useRef<SwiperRef>(null);
 
   const cardCount = events.length;
-  const extendedEvents = cardCount < 5 ? extendArrayToFive(events) : events;
+  const extendedEvents =
+    cardCount < MIN_CARD_COUNT ? extendArray(events) : events;
 
   return (
     <>
@@ -72,14 +75,14 @@ const EventsSwiperView = ({ events, type }: Props) => {
 
 export default EventsSwiperView;
 
-const extendArrayToFive = <T,>(arr: T[]): T[] => {
+const extendArray = <T,>(arr: T[]): T[] => {
   if (arr.length === 0) {
     return [];
   }
 
   const result: T[] = [];
-  while (result.length < 5) {
+  while (result.length < MIN_CARD_COUNT) {
     result.push(...arr);
   }
-  return result.slice(0, 5);
+  return result;
 };


### PR DESCRIPTION
## 개요

캐러셀의 카드 개수를 extend를 할 때 1, 2, 3, 1, 2 로 루프가 돌 수 있던 케이스를 처리했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).