### PR TITLE
fix: 홈의 행사 캐러셀 api 조건 수정 및 스크롤 이슈 해결

### DIFF
--- a/src/app/(home)/@event/components/CardSection.tsx
+++ b/src/app/(home)/@event/components/CardSection.tsx
@@ -27,7 +27,7 @@ interface TitleProps {
 
 const Title = ({ title, showMore }: TitleProps) => {
   return (
-    <header className="flex w-full flex-row justify-between">
+    <header className="flex w-full flex-row justify-between pb-16">
       <h2 className={'text-20 font-700 leading-[140%]'}>{title}</h2>
       {showMore && (
         <Link href={showMore}>

--- a/src/app/(home)/@event/components/RecommendedEventCard.tsx
+++ b/src/app/(home)/@event/components/RecommendedEventCard.tsx
@@ -13,7 +13,7 @@ import Empty from '@/app/event/components/Empty';
 const RecommendedEventCard = () => {
   const [type, setType] = useState<EventType>('CONCERT');
   const { data: recommendedEvents, isLoading } = useGetEvents({
-    status: 'OPEN',
+    status: 'OPEN,CLOSED',
     eventIsPinned: true,
   });
 
@@ -45,7 +45,7 @@ const RecommendedEventCard = () => {
         showMore="/event"
       >
         {availableEventTypes.length > 1 && (
-          <div className="flex gap-8 pt-16">
+          <div className="flex gap-8 pb-16">
             {availableEventTypes.map((eventType) => (
               <Chip
                 key={eventType}
@@ -62,9 +62,7 @@ const RecommendedEventCard = () => {
         ) : !filteredEvents ? (
           <Empty />
         ) : (
-          <div>
-            <RecommendedEventSwiperView events={filteredEvents} />
-          </div>
+          <RecommendedEventSwiperView events={filteredEvents} />
         )}
       </CardSection>
     </section>

--- a/src/app/(home)/@event/components/RecommendedEventSwiperView.tsx
+++ b/src/app/(home)/@event/components/RecommendedEventSwiperView.tsx
@@ -18,52 +18,50 @@ const RecommendedEventSwiperView = ({ events }: Props) => {
   const swiper = useRef<SwiperRef>(null);
 
   return (
-    <>
-      <div className={'relative w-[calc(100%+16px)] py-16'}>
-        <Swiper
-          ref={swiper}
-          pagination={true}
-          slidesPerView="auto"
-          navigation={true}
-          className="relative w-full"
-        >
-          {events?.map((v, idx) => (
-            <SwiperSlide key={v.eventId} style={{ width: 'auto' }}>
-              <div className="pr-[6px]">
-                <Card
-                  variant={'MEDIUM'}
-                  image={v.eventImageUrl}
-                  title={v.eventName}
-                  date={dateString([v.startDate, v.endDate], {
-                    showWeekday: false,
-                  })}
-                  location={v.eventLocationName}
-                  price={`${v.minRoutePrice?.toLocaleString()}원 ~`}
-                  isSaleStarted={v.hasOpenRoute}
-                  order={idx + 1}
-                  href={`/event/${v.eventId}`}
-                />
-              </div>
-            </SwiperSlide>
-          ))}
-          {
-            <SwiperSlide style={{ width: 'auto' }}>
-              <Link
-                href="/event"
-                className="group flex h-[300px] w-92 cursor-pointer flex-col items-center gap-[8px] pr-[6px]
+    <div className={'relative w-[calc(100%+16px)]'}>
+      <Swiper
+        ref={swiper}
+        pagination={true}
+        slidesPerView="auto"
+        navigation={true}
+        className="relative w-full"
+      >
+        {events?.map((v, idx) => (
+          <SwiperSlide key={v.eventId} style={{ width: 'auto' }}>
+            <div className="pr-[6px]">
+              <Card
+                variant={'MEDIUM'}
+                image={v.eventImageUrl}
+                title={v.eventName}
+                date={dateString([v.startDate, v.endDate], {
+                  showWeekday: false,
+                })}
+                location={v.eventLocationName}
+                price={`${v.minRoutePrice?.toLocaleString()}원 ~`}
+                isSaleStarted={v.hasOpenRoute}
+                order={idx + 1}
+                href={`/event/${v.eventId}`}
+              />
+            </div>
+          </SwiperSlide>
+        ))}
+        {
+          <SwiperSlide style={{ width: 'auto' }}>
+            <Link
+              href="/event"
+              className="group flex h-[300px] w-92 cursor-pointer flex-col items-center gap-[8px] pr-[6px]
     pt-72
     transition-colors"
-              >
-                <ViewAllButton />
-                <p className="text-14 font-600 leading-[160%] text-basic-grey-600">
-                  전체보기
-                </p>
-              </Link>
-            </SwiperSlide>
-          }
-        </Swiper>
-      </div>
-    </>
+            >
+              <ViewAllButton />
+              <p className="text-14 font-600 leading-[160%] text-basic-grey-600">
+                전체보기
+              </p>
+            </Link>
+          </SwiperSlide>
+        }
+      </Swiper>
+    </div>
   );
 };
 

--- a/src/app/(home)/@event/components/RecommendedEventSwiperView.tsx
+++ b/src/app/(home)/@event/components/RecommendedEventSwiperView.tsx
@@ -18,7 +18,7 @@ const RecommendedEventSwiperView = ({ events }: Props) => {
   const swiper = useRef<SwiperRef>(null);
 
   return (
-    <div className={'relative w-[calc(100%+16px)]'}>
+    <div className={'relative -mx-16 w-[calc(100%+32px)]'}>
       <Swiper
         ref={swiper}
         pagination={true}
@@ -26,6 +26,9 @@ const RecommendedEventSwiperView = ({ events }: Props) => {
         navigation={true}
         className="relative w-full"
       >
+        <SwiperSlide style={{ width: 'auto' }}>
+          <div className="w-16" />
+        </SwiperSlide>
         {events?.map((v, idx) => (
           <SwiperSlide key={v.eventId} style={{ width: 'auto' }}>
             <div className="pr-[6px]">

--- a/src/app/(home)/@event/components/TrendEventCard.tsx
+++ b/src/app/(home)/@event/components/TrendEventCard.tsx
@@ -6,7 +6,7 @@ import TrendEventsSwiperView from './TrendEventsSwiperView';
 
 const TrendEventCard = () => {
   const { data: popularEvents } = useGetEvents({
-    status: 'OPEN',
+    status: 'OPEN,CLOSED',
     orderBy: 'eventRecommendationScore',
     additionalOrderOptions: 'DESC',
   });

--- a/src/app/(home)/@event/components/TrendEventsSwiperView.tsx
+++ b/src/app/(home)/@event/components/TrendEventsSwiperView.tsx
@@ -22,7 +22,7 @@ const TrendEventsSwiperView = ({ events }: Props) => {
 
   return (
     <>
-      <div className={'relative -mx-16 w-[calc(100%+32px)] py-16'}>
+      <div className={'relative -mx-16 w-[calc(100%+32px)]'}>
         <Swiper
           ref={swiper}
           pagination={true}

--- a/src/services/event.service.ts
+++ b/src/services/event.service.ts
@@ -4,11 +4,11 @@ import {
   EventWithRoutesViewEntitySchema,
 } from '@/types/event.type';
 import { instance } from './config';
-import { withPagination } from '@/types/common.type';
+import { Combinations, withPagination } from '@/types/common.type';
 import { toSearchParams } from '@/utils/searchParams.util';
 
 export const getEvents = async (params?: {
-  status?: EventStatus;
+  status?: Combinations<EventStatus>;
   eventIsPinned?: boolean;
   orderBy?: 'eventName' | 'eventRecommendationScore';
   additionalOrderOptions?: 'ASC' | 'DESC';
@@ -26,7 +26,7 @@ export const getEvents = async (params?: {
 };
 
 export const useGetEvents = (params?: {
-  status?: EventStatus;
+  status?: Combinations<EventStatus>;
   eventIsPinned?: boolean;
   orderBy?: 'eventName' | 'eventRecommendationScore';
   additionalOrderOptions?: 'ASC' | 'DESC';


### PR DESCRIPTION
## 개요

- 홈에서 행사 캐러셀 내부의 행사들을 가져올 때 수요조사가 마감된 행사들도 받아오도록 수정했습니다.
- 캐러셀 스크롤 이슈를 해결했습니다.
- 캐러셀 패딩을 피그마 디자인에 맞게 수정했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).