### PR TITLE
fix: 행사 전체보기 페이지에서 목데이터만 표시되는 이슈해결

### DIFF
--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -12,6 +12,7 @@ import { useMemo, useState } from 'react';
 import { EventType } from '@/types/event.type';
 import FilterBar from './components/FilterBar';
 import { EventSortType } from '@/app/event/event.const';
+import { dateString } from '@/utils/dateString.util';
 
 const Page = () => {
   const [type, setType] = useState<EventType>('CONCERT');
@@ -52,6 +53,12 @@ const Page = () => {
                 image={event.eventImageUrl}
                 variant="SMALL"
                 title={event.eventName}
+                date={dateString([event.startDate, event.endDate], {
+                  showWeekday: false,
+                })}
+                location={event.eventLocationName}
+                price={`${event.minRoutePrice?.toLocaleString()}원 ~`}
+                isSaleStarted={event.hasOpenRoute}
                 href={`/event/${event.eventId}`}
               />
             </div>

--- a/src/app/event/toSorted.util.ts
+++ b/src/app/event/toSorted.util.ts
@@ -1,9 +1,12 @@
 import { EventSortType } from '@/app/event/event.const';
-import { EventsViewEntity } from '@/types/event.type';
+import { EventWithRoutesViewEntity } from '@/types/event.type';
 import dayjs from 'dayjs';
 
-export const toSorted = (events: EventsViewEntity[], sort: EventSortType) => {
-  let newData: EventsViewEntity[];
+export const toSorted = (
+  events: EventWithRoutesViewEntity[],
+  sort: EventSortType,
+) => {
+  let newData: EventWithRoutesViewEntity[];
   switch (sort) {
     case 'NAME_ASC':
       newData = events.toSorted((a, b) =>

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -73,10 +73,10 @@ export default Card;
 
 const LargeCard = ({
   image,
-  order = 1,
+  order,
   isSaleStarted,
-  title = 'ATEEZ 2024 FANMEETING 〈ATINY&apos;S VOYAGE FROM A TO Z〉',
-  price = '32,000원~',
+  title,
+  price,
   href,
 }: Props) => {
   return (
@@ -122,9 +122,9 @@ const LargeCard = ({
 const MediumCard = ({
   image,
   isSaleStarted,
-  title = 'ATEEZ 2024 FANMEETING 〈ATINY’S VOYAGE FROM A TO Z〉',
-  date = '2024.02.01 - 02.03',
-  price = '32,000원~',
+  title,
+  date,
+  price,
   href,
 }: Props) => {
   return (
@@ -166,10 +166,10 @@ const MediumCard = ({
 const SmallCard = ({
   image,
   isSaleStarted,
-  title = 'ATEEZ 2024 FANMEETING 〈ATINY’S VOYAGE FROM A TO Z〉',
-  date = '2024.02.01 - 02.03',
-  location = '잠실실내체육관',
-  price = '32,000원~',
+  title,
+  date,
+  location,
+  price,
   href,
 }: Props) => {
   return (


### PR DESCRIPTION
## 개요
행사 전체보기에서 카드의 값에 실제 데이터를 보여줍니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).