### PR TITLE
fix: 리뷰 전체보기에서 최신순 정렬 반대로 되어있던 이슈 해결

### DIFF
--- a/src/app/mypage/reviews/[reviewId]/components/FilterButton.tsx
+++ b/src/app/mypage/reviews/[reviewId]/components/FilterButton.tsx
@@ -43,7 +43,7 @@ const FilterButton = ({ sort, onSort }: FilterButtonProps) => {
           onClick={() => setFilterOpen(!filterOpen)}
           className="flex h-[38px]  items-center gap-8 break-keep rounded-8 border-[1px] border-basic-grey-200 px-12 py-8 text-14 font-600 leading-[160%] text-basic-grey-600 active:bg-basic-grey-50"
         >
-          {sort === 'DATE_ASC'
+          {sort === 'DATE_DESC'
             ? '최신순'
             : sort === 'RATING_ASC'
               ? '별점낮은순'
@@ -54,9 +54,9 @@ const FilterButton = ({ sort, onSort }: FilterButtonProps) => {
       {filterOpen && (
         <div className="absolute right-0 top-44 z-50 w-[110px] rounded-[8px] border border-basic-grey-200 bg-basic-white shadow-lg">
           <button
-            onClick={() => handleSort('DATE_ASC')}
+            onClick={() => handleSort('DATE_DESC')}
             className={`w-full px-16 py-12 text-left text-14 font-600 leading-[160%] hover:bg-basic-grey-50 ${
-              sort === 'DATE_ASC'
+              sort === 'DATE_DESC'
                 ? 'text-brand-primary-400'
                 : 'text-basic-grey-700'
             }`}

--- a/src/app/mypage/reviews/[reviewId]/components/ReviewListWithMyReview.tsx
+++ b/src/app/mypage/reviews/[reviewId]/components/ReviewListWithMyReview.tsx
@@ -11,7 +11,7 @@ import { useMemo } from 'react';
 import { useState } from 'react';
 import FilterButton from './FilterButton';
 
-export type ReviewSortType = 'DATE_ASC' | 'RATING_DESC' | 'RATING_ASC';
+export type ReviewSortType = 'DATE_DESC' | 'RATING_DESC' | 'RATING_ASC';
 
 interface Props {
   reviewId?: string;
@@ -21,7 +21,7 @@ const ReviewListWithMyReview = ({ reviewId }: Props) => {
   const { data, fetchNextPage, isFetching, hasNextPage } =
     useGetReviewsWithPagination();
 
-  const [sort, setSort] = useState<ReviewSortType>('DATE_ASC');
+  const [sort, setSort] = useState<ReviewSortType>('DATE_DESC');
   const ref = useInfiniteScroll(fetchNextPage);
   const reviews = data.reviews;
 
@@ -38,7 +38,7 @@ const ReviewListWithMyReview = ({ reviewId }: Props) => {
       if (sort === 'RATING_DESC') {
         return b.rating - a.rating;
       }
-      return a.createdAt.localeCompare(b.createdAt);
+      return b.createdAt.localeCompare(a.createdAt);
     });
   }, [sort, reviewListWithoutMyReview]);
 

--- a/src/app/reviews/components/FilterButton.tsx
+++ b/src/app/reviews/components/FilterButton.tsx
@@ -43,7 +43,7 @@ const FilterButton = ({ sort, onSort }: FilterButtonProps) => {
           onClick={() => setFilterOpen(!filterOpen)}
           className="flex h-[38px]  items-center gap-8 break-keep rounded-8 border-[1px] border-basic-grey-200 px-12 py-8 text-14 font-600 leading-[160%] text-basic-grey-600 active:bg-basic-grey-50"
         >
-          {sort === 'DATE_ASC'
+          {sort === 'DATE_DESC'
             ? '최신순'
             : sort === 'RATING_ASC'
               ? '별점낮은순'
@@ -54,9 +54,9 @@ const FilterButton = ({ sort, onSort }: FilterButtonProps) => {
       {filterOpen && (
         <div className="absolute right-0 top-44 z-50 w-[110px] rounded-[8px] border border-basic-grey-200 bg-basic-white shadow-lg">
           <button
-            onClick={() => handleSort('DATE_ASC')}
+            onClick={() => handleSort('DATE_DESC')}
             className={`w-full px-16 py-12 text-left text-14 font-600 leading-[160%] hover:bg-basic-grey-50 ${
-              sort === 'DATE_ASC'
+              sort === 'DATE_DESC'
                 ? 'text-brand-primary-400'
                 : 'text-basic-grey-700'
             }`}

--- a/src/app/reviews/components/ReviewList.tsx
+++ b/src/app/reviews/components/ReviewList.tsx
@@ -9,7 +9,7 @@ import { useGetReviewsWithPagination } from '@/services/review.service';
 import FilterButton from './FilterButton';
 import { useMemo, useState } from 'react';
 
-export type ReviewSortType = 'DATE_ASC' | 'RATING_DESC' | 'RATING_ASC';
+export type ReviewSortType = 'DATE_DESC' | 'RATING_DESC' | 'RATING_ASC';
 
 const ReviewList = () => {
   const { data, fetchNextPage, isFetching, hasNextPage } =
@@ -17,7 +17,7 @@ const ReviewList = () => {
 
   const ref = useInfiniteScroll(fetchNextPage);
 
-  const [sort, setSort] = useState<ReviewSortType>('DATE_ASC');
+  const [sort, setSort] = useState<ReviewSortType>('DATE_DESC');
 
   const sortedReviews = useMemo(() => {
     return data.reviews.sort((a, b) => {
@@ -27,7 +27,7 @@ const ReviewList = () => {
       if (sort === 'RATING_DESC') {
         return b.rating - a.rating;
       }
-      return a.createdAt.localeCompare(b.createdAt);
+      return b.createdAt.localeCompare(a.createdAt);
     });
   }, [sort, data.reviews]);
 


### PR DESCRIPTION
## 개요
최신순의 정렬이 반대로 되어있던 걸 고쳤습니다.

## 변경사항

https://github.com/user-attachments/assets/f8bc553e-ac25-4a46-b198-e1ea14138159



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).