### PR TITLE
hotfix: 행사의 노선이 페이지 이동에 따라 중첩되는 현상 해결

### DIFF
--- a/src/app/event/[eventId]/store/dailyEventIdsWithRoutesAtom.ts
+++ b/src/app/event/[eventId]/store/dailyEventIdsWithRoutesAtom.ts
@@ -9,8 +9,7 @@ const primitiveDailyEventIdsWithRoutesAtom = atom<DailyEventIdsWithRoutes>({});
 
 export const dailyEventIdsWithRoutesAtom = atom(
   (get) => get(primitiveDailyEventIdsWithRoutesAtom),
-  (get, set, routes: ShuttleRoutesViewEntity[]) => {
-    const prev = get(primitiveDailyEventIdsWithRoutesAtom);
+  (_, set, routes: ShuttleRoutesViewEntity[]) => {
     const newDailyEventIdWithRoutes = routes.reduce((acc, route) => {
       const dailyEventId = route.dailyEventId;
       const prevRoutes = acc[dailyEventId] || [];
@@ -22,7 +21,7 @@ export const dailyEventIdsWithRoutesAtom = atom(
       }
       acc[dailyEventId] = [...prevRoutes, route];
       return acc;
-    }, prev);
+    }, {} as DailyEventIdsWithRoutes);
     set(primitiveDailyEventIdsWithRoutesAtom, newDailyEventIdWithRoutes);
   },
 );


### PR DESCRIPTION
## 개요

행사 상세 페이지에서 노선들을 불러와 상태관리로 저장하던 값들이 페이지 이동에 따라 초기화 되지 않고 중첩되던 현상을 해결했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).