### PR TITLE
fix: 프로필 수정 시 프로필 이미지 초기화 되던 이슈 해결

### DIFF
--- a/src/app/mypage/profile/edit/components/EditForm.tsx
+++ b/src/app/mypage/profile/edit/components/EditForm.tsx
@@ -93,7 +93,7 @@ const EditForm = ({ type, user }: Props) => {
       ageRange: formData.age,
       gender:
         formData.gender === '남성' ? ('MALE' as const) : ('FEMALE' as const),
-      profileImage: imageUrl ?? null,
+      profileImage: imageUrl ?? undefined,
       favoriteArtistsIds,
       regionId,
     };


### PR DESCRIPTION
## 개요

프로필을 수정할 시 프로필 이미지가 초기화 되던 이슈를 해결했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).