### PR TITLE
fix: 열린 셔틀 보기로 입장 시 수요조사가 다른 지역으로 뜨던 현상 해결

### DIFF
--- a/src/app/event/[eventId]/components/steps/demand-steps/DemandHubsStep.tsx
+++ b/src/app/event/[eventId]/components/steps/demand-steps/DemandHubsStep.tsx
@@ -28,14 +28,19 @@ const DemandHubsStep = ({ toNextStep }: Props) => {
   const event = useAtomValue(eventAtom);
   const userDemands = useAtomValue(userDemandsAtom);
   const { getValues, setValue } = useFormContext<EventFormValues>();
-  const [sido, dailyEvent] = getValues(['sido', 'dailyEvent']);
+  const [dailyEvent, sido, openSido] = getValues([
+    'dailyEvent',
+    'sido',
+    'openSido',
+  ]);
   const enabled = !!sido && !!event?.eventId && !!dailyEvent.dailyEventId;
+  const prioritySido = openSido ?? sido;
 
   const { data: regionsWithHubsPages } = useGetHubsWithPagination(
     {
       // TODO: 장소 태깅 완료하고 주석 해제하기
       // usageType: 'SHUTTLE_HUB',
-      provinceFullName: sido,
+      provinceFullName: prioritySido,
     },
     { enabled },
   );
@@ -45,7 +50,7 @@ const DemandHubsStep = ({ toNextStep }: Props) => {
       groupBy: 'CITY',
       eventId: event?.eventId,
       dailyEventId: dailyEvent.dailyEventId,
-      provinceFullName: sido,
+      provinceFullName: prioritySido,
     },
     { enabled },
   );
@@ -64,7 +69,7 @@ const DemandHubsStep = ({ toNextStep }: Props) => {
       };
     });
     const groupedHubs = groupHubsByRegion(hubsWithRegion);
-    const gungusWithHubs = groupedHubs?.[sido] ?? [];
+    const gungusWithHubs = groupedHubs?.[prioritySido] ?? [];
     const gungusWithFlattenedHubs = Object.entries(gungusWithHubs)
       .map(([gungu, hubs]) => {
         return {
@@ -83,7 +88,7 @@ const DemandHubsStep = ({ toNextStep }: Props) => {
       };
     });
     return gungusWithDemandStats;
-  }, [regionsWithHubsPages, demandStats]);
+  }, [regionsWithHubsPages, demandStats, prioritySido]);
 
   const handleHubClick = (hub: RegionHubsResponseModel) => {
     setValue('selectedHubForDemand', hub);
@@ -131,7 +136,7 @@ const DemandHubsStep = ({ toNextStep }: Props) => {
       )}
       <div>
         {gungusWithHubs.map((gunguWithHubs, index) => {
-          const regionId = REGION_TO_ID?.[sido]?.[gunguWithHubs.gungu];
+          const regionId = REGION_TO_ID?.[prioritySido]?.[gunguWithHubs.gungu];
           if (!regionId || !event) {
             return null;
           }

--- a/src/app/event/[eventId]/components/steps/extra-steps/ExtraSidoInfoStep.tsx
+++ b/src/app/event/[eventId]/components/steps/extra-steps/ExtraSidoInfoStep.tsx
@@ -17,7 +17,7 @@ const ExtraSidoInfoStep = ({
   toDemandHubsStep,
 }: Props) => {
   const event = useAtomValue(eventAtom);
-  const { getValues } = useFormContext<EventFormValues>();
+  const { getValues, setValue } = useFormContext<EventFormValues>();
   const [dailyEvent, sido] = getValues(['dailyEvent', 'sido']);
   const enabled = !!event?.eventId && !!dailyEvent.dailyEventId && !!sido;
 
@@ -31,6 +31,11 @@ const ExtraSidoInfoStep = ({
     { enabled },
   );
   const demandCount = demandStats?.[0]?.totalCount ?? 0;
+
+  const handleDemandClick = () => {
+    setValue('openSido', undefined);
+    toDemandHubsStep();
+  };
 
   return (
     <section className="flex w-full flex-col gap-16">
@@ -56,7 +61,7 @@ const ExtraSidoInfoStep = ({
           열린 셔틀 보기
         </Button>
         <Button
-          onClick={toDemandHubsStep}
+          onClick={handleDemandClick}
           variant="primary"
           size="large"
           type="button"


### PR DESCRIPTION
## 개요

행사 상세 보기에서 열린 셔틀 보기를 통해 지역을 선택 했을 시, 수요조사를 요청하면 지역이 처음에 선택한 지역으로 띄워지던 버그를 수정했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).