### PR TITLE
fix: 내 후기 버그 수정 및 피드백 반영

### DIFF
--- a/src/app/mypage/reviews/components/WritableReviews.tsx
+++ b/src/app/mypage/reviews/components/WritableReviews.tsx
@@ -9,9 +9,7 @@ import { useMemo } from 'react';
 import dayjs from 'dayjs';
 
 const WritableReviews = () => {
-  const { data: reservations, isLoading } = useGetUserReservations({
-    eventProgressStatus: 'PAST',
-  });
+  const { data: reservations, isLoading } = useGetUserReservations({});
 
   const reservationsWithNotWrittenReview = useMemo(
     () =>
@@ -21,12 +19,12 @@ const WritableReviews = () => {
           (dailyEvent) =>
             dailyEvent.dailyEventId === reservation.shuttleRoute.dailyEventId,
         );
-        return (
+        const isBefore7Days =
           dailyEvent &&
           dayjs()
             .tz('Asia/Seoul')
-            .isBefore(dayjs(dailyEvent.date).tz('Asia/Seoul').add(7, 'day'))
-        );
+            .isBefore(dayjs(dailyEvent.date).tz('Asia/Seoul').add(7, 'day'));
+        return isBefore7Days;
       }),
     [reservations],
   );

--- a/src/app/mypage/reviews/components/reservation-card/ReviewButton.tsx
+++ b/src/app/mypage/reviews/components/reservation-card/ReviewButton.tsx
@@ -59,7 +59,7 @@ const ReviewButton = ({
           variant="tertiary"
           size="small"
           onClick={handleClickAndStopPropagation(() => {
-            router.push(`/mypage/reviews/${reservationId}`);
+            router.push(`/mypage/reviews/${reviewId}`);
           })}
         >
           내 후기

--- a/src/app/mypage/reviews/write/[reservationId]/page.tsx
+++ b/src/app/mypage/reviews/write/[reservationId]/page.tsx
@@ -6,6 +6,7 @@ import ReviewWriteForm from './components/ReviewWriteForm';
 import { useGetUserReservation } from '@/services/reservation.service';
 import DeferredSuspense from '@/components/loading/DeferredSuspense';
 import Loading from '@/components/loading/Loading';
+import { useRouter } from 'next/navigation';
 
 interface Props {
   params: {
@@ -18,7 +19,9 @@ const WriteReviewPage = ({ params }: Props) => {
   const { data, isLoading } = useGetUserReservation(reservationId);
   const event = data?.reservation.shuttleRoute.event;
   const reservation = data?.reservation;
+  const { replace } = useRouter();
 
+  if (data?.reservation.reviewId) replace(`/mypage/reviews/`);
   return (
     <main>
       <Header />


### PR DESCRIPTION
## 개요
작성가능한 후기가 안뜨던 버그 수정, 작성한 후기가 강조표기가 안되던 이슈 해결, 후기 작성하기 재진입 방지 적용

## 변경사항
- 작성가능한 후기가 안뜨던 이슈를 해결하였습니다.
  - 요약 : 최근 노선의 상태 변경 로직이 변화되어 수정이 필요했습니다. 
  - 원인 : 기존 `eventProgressStatus: 'PAST'` 인 행사들을 보여주고 있었습니다. 이는 기존 정책이 행사에 속한 모든 노선이 종료되면 행사의 상태 및 노선의 상태가 ENDED로 변경되어서 가능했던 로직이었습니다. 
  - 해결 : 이제 각 노선단위로 ENDED로 변경되기에 `eventProgressStatus: 'PAST'`를 사용하지 않습니다.
- 작성한 후기 - 내 후기 클릭 - 나의 후기가 강조 표기가 안되던 이슈가 해결되었습니다.
- 후기 작성 : 후기를 작성하고 난 뒤, 뒤로가기 등을 사용하여 같은 url에 진입하면 마이페이지 내 후기 목록 페이지로 리디렉트 됩니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).