### PR TITLE
fix: trip type 순서를 왕복을 마지막으로 변경

### DIFF
--- a/src/app/reservation/[id]/components/PriceStats.tsx
+++ b/src/app/reservation/[id]/components/PriceStats.tsx
@@ -53,13 +53,6 @@ const PriceStats = ({
       </header>
       <section className="flex flex-col gap-12">
         <Card
-          tripType="ROUND_TRIP"
-          regularPrice={regularPrice.roundTrip}
-          isEarlybird={isEarlybird}
-          earlybirdPrice={earlybirdPrice.roundTrip}
-          remainingSeat={roundTripRemainingSeat}
-        />
-        <Card
           tripType="TO_DESTINATION"
           region={region}
           destination={destination}
@@ -76,6 +69,13 @@ const PriceStats = ({
           isEarlybird={isEarlybird}
           earlybirdPrice={earlybirdPrice.fromDestination}
           remainingSeat={remainingSeat.fromDestination}
+        />
+        <Card
+          tripType="ROUND_TRIP"
+          regularPrice={regularPrice.roundTrip}
+          isEarlybird={isEarlybird}
+          earlybirdPrice={earlybirdPrice.roundTrip}
+          remainingSeat={roundTripRemainingSeat}
         />
       </section>
     </article>

--- a/src/app/reservation/[id]/write/components/steps/RouteSelectStep.tsx
+++ b/src/app/reservation/[id]/write/components/steps/RouteSelectStep.tsx
@@ -278,8 +278,8 @@ const TypeSelect = () => {
             disableOption={(option) => getRemainingSeatCount(option) === 0}
             isUnderLined
             defaultText="예약 가능한 좌석이 없어요"
-            placeholder="왕복 / 가는 편 / 오는 편"
-            bottomSheetTitle="왕복 / 가는 편 / 오는 편 선택"
+            placeholder="가는 편 / 오는 편 / 왕복"
+            bottomSheetTitle="가는 편 / 오는 편 / 왕복 선택"
           />
         );
       }}

--- a/src/types/shuttleRoute.type.ts
+++ b/src/types/shuttleRoute.type.ts
@@ -14,9 +14,9 @@ export const ShuttleRouteStatusEnum = z.enum([
 export type ShuttleRouteStatus = z.infer<typeof ShuttleRouteStatusEnum>;
 
 export const TripTypeEnum = z.enum([
-  'ROUND_TRIP', // 왕복
   'TO_DESTINATION', // 가는 편
   'FROM_DESTINATION', // 오는 편
+  'ROUND_TRIP', // 왕복
 ]);
 export type TripType = z.infer<typeof TripTypeEnum>;
 


### PR DESCRIPTION
## 개요
왕복 가격을 마지막 순서로 배치합니다.

## 변경사항
### 결론 : 왕복 가격을 마지막 순서로 배치합니다.

### 배경
타다 상품 셔틀의 도입, 주로 오는편만 이용하는 승객이 대부분. 대형 택시 상품이다보니 상품가가 버스에 비해 높음
버스상품은 왕복가와 편도가가 크게차이나지 않았음. 그러나 택시 상품의 경우 왕복가가 편도상품의 2배 가격임.
주로 오는 편만 예매하는 고객이 대부분임에도, 예약 상세페이지에서 상품 예약을 할때 왕복가가 제일 상단에 먼저 보이면
가격이 비싸보이는 인식을 주게됨. 그래서 왕복가격을 제일 하단으로 순서를 변경하여 편도가를 기준으로 가격을 인지하게 만드려고함.

https://github.com/user-attachments/assets/748b88ce-0fe2-48b3-ab3e-4dc4cf383b1a


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).