### PR TITLE
fix: 택시 정류장 보여주지 않도록 처리

### DIFF
--- a/src/app/demand/[id]/write/components/JourneyLocationPicker.tsx
+++ b/src/app/demand/[id]/write/components/JourneyLocationPicker.tsx
@@ -5,7 +5,7 @@ import Select from '@/components/select/Select';
 import { Controller, useWatch } from 'react-hook-form';
 import { useFormContext } from 'react-hook-form';
 import { FormValues } from './WriteForm';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useGetHubsByRegionId } from '@/services/hub.service';
 
 const JourneyLocationPicker = () => {
@@ -21,12 +21,17 @@ const JourneyLocationPicker = () => {
   const [isToDestinationCustom, setIsToDestinationCustom] = useState(false);
   const [isFromDestinationCustom, setIsFromDestinationCustom] = useState(false);
 
+  const regionHubsExcludedTaxi = useMemo(
+    () => regionHubs.filter((hub) => !hub.name.includes('[집앞하차]')),
+    [regionHubs],
+  );
+
   useEffect(() => {
     setIsToDestinationCustom(false);
     setIsFromDestinationCustom(false);
   }, [type]);
 
-  if (!type || (!regionId && regionHubs.length === 0)) {
+  if (!type || (!regionId && regionHubsExcludedTaxi.length === 0)) {
     return null;
   }
 
@@ -46,7 +51,7 @@ const JourneyLocationPicker = () => {
             render={({ field: { value, onChange } }) => (
               <Select
                 options={[
-                  ...regionHubs,
+                  ...regionHubsExcludedTaxi,
                   { name: '기타 (직접 입력)', regionHubId: null },
                 ]}
                 value={value}
@@ -82,7 +87,7 @@ const JourneyLocationPicker = () => {
             render={({ field: { value, onChange } }) => (
               <Select
                 options={[
-                  ...regionHubs,
+                  ...regionHubsExcludedTaxi,
                   { name: '기타 (직접 입력)', regionHubId: null },
                 ]}
                 value={value}


### PR DESCRIPTION
## 개요
v1 프로덕트에서 수요조사시에 [집앞하차] 접두사가 붙은 정류장은 보여주지 않도록 처리합니다.

## 변경사항
- 지금은 [집앞하차] 키워드를 가지고 분별하지만, env 값으로 대체할 수도 있습니다. 정류장명이 집앞하차가 아닌, 타다 정류장 등으로 바뀔 수 있다면..

<img width="1089" alt="Screenshot 2025-05-31 at 1 07 34 PM" src="https://github.com/user-attachments/assets/be48559e-c49f-4aa6-8c96-6fe47387c4f8" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).