### PR TITLE
feat: 리뷰 피드백 텍스트 api 반영

### DIFF
--- a/src/app/(home)/@bot/components/PromotionReviews.tsx
+++ b/src/app/(home)/@bot/components/PromotionReviews.tsx
@@ -5,6 +5,7 @@ import Article from '@/components/article/Article';
 import { ReviewsViewEntity } from '@/types/review.type';
 import UserProfile from '@/components/header/UserProfile';
 import { dateString } from '@/utils/dateString.util';
+import FeedbackGroup from '@/components/review/FeedbackGroup';
 
 export const revalidate = DEFAULT_SSG_REVALIDATE_TIME;
 
@@ -35,7 +36,7 @@ const PromotionReview = async () => {
               </div>
               <Rating size="medium" value={review.rating} />
             </div>
-            <FeedbackGroup />
+            <FeedbackGroup review={review} />
             <p className="line-clamp-2 overflow-hidden text-14 font-500 leading-[160%] text-basic-grey-600">
               {review.content}
             </p>
@@ -57,45 +58,3 @@ const PromotionReview = async () => {
 };
 
 export default PromotionReview;
-
-const FeedbackGroup = () => {
-  return (
-    <div className="flex gap-[6px] ">
-      <PassengerRegion />
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-200">|</p>
-      <FeedbackCard type="서비스" text="매우 만족" />
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-200">|</p>
-      <FeedbackCard type="탑승" text="매우 만족" />
-    </div>
-  );
-};
-
-const PassengerRegion = () => {
-  return (
-    <p className="text-12 font-500 leading-[160%] text-basic-grey-700">
-      경남 탑승객
-    </p>
-  );
-};
-
-const FeedbackCard = ({
-  type,
-  text,
-}: {
-  type: FeedbackType;
-  text: FeedbackText;
-}) => {
-  return (
-    <div className="flex items-center gap-4">
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-700">
-        {type}
-      </p>
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-500">
-        {text}
-      </p>
-    </div>
-  );
-};
-
-type FeedbackType = '서비스' | '탑승';
-type FeedbackText = '매우 불만족' | '불만족' | '보통' | '만족' | '매우 만족';

--- a/src/app/(home)/@bot/components/PromotionReviews.tsx
+++ b/src/app/(home)/@bot/components/PromotionReviews.tsx
@@ -5,7 +5,7 @@ import Article from '@/components/article/Article';
 import { ReviewsViewEntity } from '@/types/review.type';
 import UserProfile from '@/components/header/UserProfile';
 import { dateString } from '@/utils/dateString.util';
-import FeedbackGroup from '@/components/review/FeedbackGroup';
+import ReviewProperty from '@/components/review/ReviewProperty';
 
 export const revalidate = DEFAULT_SSG_REVALIDATE_TIME;
 
@@ -36,7 +36,7 @@ const PromotionReview = async () => {
               </div>
               <Rating size="medium" value={review.rating} />
             </div>
-            <FeedbackGroup review={review} />
+            <ReviewProperty review={review} />
             <p className="line-clamp-2 overflow-hidden text-14 font-500 leading-[160%] text-basic-grey-600">
               {review.content}
             </p>

--- a/src/app/mypage/reviews/[reviewId]/components/ReviewItem.tsx
+++ b/src/app/mypage/reviews/[reviewId]/components/ReviewItem.tsx
@@ -5,7 +5,7 @@ import { useCallback, useRef, useState } from 'react';
 import Image from 'next/image';
 import { dateString } from '@/utils/dateString.util';
 import ImageModal from './ImageModal';
-import FeedbackGroup from '@/components/review/FeedbackGroup';
+import ReviewProperty from '@/components/review/ReviewProperty';
 
 interface Props {
   review: ReviewsViewEntity;
@@ -62,7 +62,7 @@ const ReviewItem = ({ review, isMyReview }: Props) => {
               </div>
               <Rating size="medium" value={review.rating} />
             </div>
-            <FeedbackGroup review={review} />
+            <ReviewProperty review={review} />
             {review.reviewImages && review.reviewImages.length > 0 && (
               <figure className="flex gap-4 py-4">
                 {review.reviewImages?.map((image, index) => {

--- a/src/app/mypage/reviews/[reviewId]/components/ReviewItem.tsx
+++ b/src/app/mypage/reviews/[reviewId]/components/ReviewItem.tsx
@@ -5,6 +5,7 @@ import { useCallback, useRef, useState } from 'react';
 import Image from 'next/image';
 import { dateString } from '@/utils/dateString.util';
 import ImageModal from './ImageModal';
+import FeedbackGroup from '@/components/review/FeedbackGroup';
 
 interface Props {
   review: ReviewsViewEntity;
@@ -61,16 +62,18 @@ const ReviewItem = ({ review, isMyReview }: Props) => {
               </div>
               <Rating size="medium" value={review.rating} />
             </div>
-            <FeedbackGroup />
-            <figure className="flex gap-4 py-4">
-              {review.reviewImages &&
-                review.reviewImages.length > 0 &&
-                review.reviewImages?.map((image, index) => {
+            <FeedbackGroup review={review} />
+            {review.reviewImages && review.reviewImages.length > 0 && (
+              <figure className="flex gap-4 py-4">
+                {review.reviewImages?.map((image, index) => {
                   return (
-                    <div
+                    <button
+                      type="button"
                       className="relative h-60 w-60"
                       key={index}
-                      onClick={() => setOpenImageUrl(image.imageUrl)}
+                      onClick={() => {
+                        setOpenImageUrl(image.imageUrl);
+                      }}
                     >
                       <Image
                         src={image.imageUrl}
@@ -78,10 +81,11 @@ const ReviewItem = ({ review, isMyReview }: Props) => {
                         fill
                         className="rounded-8 object-cover"
                       />
-                    </div>
+                    </button>
                   );
                 })}
-            </figure>
+              </figure>
+            )}
             <p
               ref={ref}
               className={`overflow-hidden text-14 font-500 leading-[160%] text-basic-grey-600 ${
@@ -122,45 +126,3 @@ const ReviewItem = ({ review, isMyReview }: Props) => {
 };
 
 export default ReviewItem;
-
-const FeedbackGroup = () => {
-  return (
-    <div className="flex gap-[6px] ">
-      <PassengerRegion />
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-200">|</p>
-      <FeedbackCard type="서비스" text="매우 만족" />
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-200">|</p>
-      <FeedbackCard type="탑승" text="매우 만족" />
-    </div>
-  );
-};
-
-const PassengerRegion = () => {
-  return (
-    <p className="text-12 font-500 leading-[160%] text-basic-grey-700">
-      경남 탑승객
-    </p>
-  );
-};
-
-const FeedbackCard = ({
-  type,
-  text,
-}: {
-  type: FeedbackType;
-  text: FeedbackText;
-}) => {
-  return (
-    <div className="flex items-center gap-4">
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-700">
-        {type}
-      </p>
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-500">
-        {text}
-      </p>
-    </div>
-  );
-};
-
-type FeedbackType = '서비스' | '탑승';
-type FeedbackText = '매우 불만족' | '불만족' | '보통' | '만족' | '매우 만족';

--- a/src/app/reviews/components/ReviewItem.tsx
+++ b/src/app/reviews/components/ReviewItem.tsx
@@ -5,6 +5,7 @@ import { useCallback, useRef, useState } from 'react';
 import Image from 'next/image';
 import { dateString } from '@/utils/dateString.util';
 import ImageModal from './ImageModal';
+import FeedbackGroup from '@/components/review/FeedbackGroup';
 
 interface Props {
   review: ReviewsViewEntity;
@@ -55,7 +56,7 @@ const ReviewItem = ({ review }: Props) => {
               </div>
               <Rating size="medium" value={review.rating} />
             </div>
-            <FeedbackGroup />
+            <FeedbackGroup review={review} />
             <figure className="flex gap-4 py-4">
               {review.reviewImages &&
                 review.reviewImages.length > 0 &&
@@ -119,45 +120,3 @@ const ReviewItem = ({ review }: Props) => {
 };
 
 export default ReviewItem;
-
-const FeedbackGroup = () => {
-  return (
-    <div className="flex gap-[6px] ">
-      <PassengerRegion />
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-200">|</p>
-      <FeedbackCard type="서비스" text="매우 만족" />
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-200">|</p>
-      <FeedbackCard type="탑승" text="매우 만족" />
-    </div>
-  );
-};
-
-const PassengerRegion = () => {
-  return (
-    <p className="text-12 font-500 leading-[160%] text-basic-grey-700">
-      경남 탑승객
-    </p>
-  );
-};
-
-const FeedbackCard = ({
-  type,
-  text,
-}: {
-  type: FeedbackType;
-  text: FeedbackText;
-}) => {
-  return (
-    <div className="flex items-center gap-4">
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-700">
-        {type}
-      </p>
-      <p className="text-12 font-500 leading-[160%] text-basic-grey-500">
-        {text}
-      </p>
-    </div>
-  );
-};
-
-type FeedbackType = '서비스' | '탑승';
-type FeedbackText = '매우 불만족' | '불만족' | '보통' | '만족' | '매우 만족';

--- a/src/app/reviews/components/ReviewItem.tsx
+++ b/src/app/reviews/components/ReviewItem.tsx
@@ -57,10 +57,9 @@ const ReviewItem = ({ review }: Props) => {
               <Rating size="medium" value={review.rating} />
             </div>
             <FeedbackGroup review={review} />
-            <figure className="flex gap-4 py-4">
-              {review.reviewImages &&
-                review.reviewImages.length > 0 &&
-                review.reviewImages?.map((image, index) => {
+            {review.reviewImages && review.reviewImages.length > 0 && (
+              <figure className="flex gap-4 py-4">
+                {review.reviewImages?.map((image, index) => {
                   return (
                     <button
                       type="button"
@@ -79,7 +78,8 @@ const ReviewItem = ({ review }: Props) => {
                     </button>
                   );
                 })}
-            </figure>
+              </figure>
+            )}
             <p
               ref={ref}
               className={`overflow-hidden text-14 font-500 leading-[160%] text-basic-grey-600 ${

--- a/src/app/reviews/components/ReviewItem.tsx
+++ b/src/app/reviews/components/ReviewItem.tsx
@@ -5,7 +5,7 @@ import { useCallback, useRef, useState } from 'react';
 import Image from 'next/image';
 import { dateString } from '@/utils/dateString.util';
 import ImageModal from './ImageModal';
-import FeedbackGroup from '@/components/review/FeedbackGroup';
+import ReviewProperty from '@/components/review/ReviewProperty';
 
 interface Props {
   review: ReviewsViewEntity;
@@ -56,7 +56,7 @@ const ReviewItem = ({ review }: Props) => {
               </div>
               <Rating size="medium" value={review.rating} />
             </div>
-            <FeedbackGroup review={review} />
+            <ReviewProperty review={review} />
             {review.reviewImages && review.reviewImages.length > 0 && (
               <figure className="flex gap-4 py-4">
                 {review.reviewImages?.map((image, index) => {

--- a/src/components/review/FeedbackGroup.tsx
+++ b/src/components/review/FeedbackGroup.tsx
@@ -1,0 +1,72 @@
+import { ID_TO_REGION } from '@/constants/regions';
+import { BIG_REGIONS_TO_SHORT_NAME } from '@/constants/regions';
+import { ReviewsViewEntity } from '@/types/review.type';
+
+interface Props {
+  review: ReviewsViewEntity;
+}
+
+const FeedbackGroup = ({ review }: Props) => {
+  const regionId =
+    review.toDestinationRegionId ?? review.fromDestinationRegionId;
+  const regionName = regionId
+    ? BIG_REGIONS_TO_SHORT_NAME[ID_TO_REGION[regionId].bigRegion]
+    : undefined;
+  const serviceRating = FEEDBACK_TEXT_LIST[review.serviceRating - 1];
+  const rideRating = FEEDBACK_TEXT_LIST[review.rideRating - 1];
+
+  return (
+    <div className="flex gap-[6px] ">
+      {regionName && <PassengerRegion regionName={regionName} />}
+      {regionName && <TextDivider />}
+      <FeedbackCard type="서비스" text={serviceRating} />
+      <TextDivider />
+      <FeedbackCard type="탑승" text={rideRating} />
+    </div>
+  );
+};
+
+export default FeedbackGroup;
+
+const PassengerRegion = ({ regionName }: { regionName: string }) => {
+  return (
+    <p className="text-12 font-500 leading-[160%] text-basic-grey-700">
+      {regionName} 탑승객
+    </p>
+  );
+};
+
+interface FeedbackCardProps {
+  type: FeedbackType;
+  text: FeedbackText;
+}
+
+const FeedbackCard = ({ type, text }: FeedbackCardProps) => {
+  return (
+    <div className="flex items-center gap-4">
+      <p className="text-12 font-500 leading-[160%] text-basic-grey-700">
+        {type}
+      </p>
+      <p className="text-12 font-500 leading-[160%] text-basic-grey-500">
+        {text}
+      </p>
+    </div>
+  );
+};
+
+type FeedbackType = '서비스' | '탑승';
+type FeedbackText = '매우 불만족' | '불만족' | '보통' | '만족' | '매우 만족';
+
+const FEEDBACK_TEXT_LIST: FeedbackText[] = [
+  '매우 불만족',
+  '불만족',
+  '보통',
+  '만족',
+  '매우 만족',
+];
+
+const TextDivider = () => {
+  return (
+    <p className="text-12 font-500 leading-[160%] text-basic-grey-200">|</p>
+  );
+};

--- a/src/components/review/ReviewProperty.tsx
+++ b/src/components/review/ReviewProperty.tsx
@@ -6,27 +6,28 @@ interface Props {
   review: ReviewsViewEntity;
 }
 
-const FeedbackGroup = ({ review }: Props) => {
+const ReviewProperty = ({ review }: Props) => {
   const regionId =
     review.toDestinationRegionId ?? review.fromDestinationRegionId;
   const regionName = regionId
     ? BIG_REGIONS_TO_SHORT_NAME[ID_TO_REGION[regionId].bigRegion]
     : undefined;
-  const serviceRating = FEEDBACK_TEXT_LIST[review.serviceRating - 1];
-  const rideRating = FEEDBACK_TEXT_LIST[review.rideRating - 1];
+  const serviceRating =
+    EXPERIENCE_SATISFACTION_TEXT_LIST[review.serviceRating - 1];
+  const rideRating = EXPERIENCE_SATISFACTION_TEXT_LIST[review.rideRating - 1];
 
   return (
     <div className="flex gap-[6px] ">
       {regionName && <PassengerRegion regionName={regionName} />}
       {regionName && <TextDivider />}
-      <FeedbackCard type="서비스" text={serviceRating} />
+      <ExperienceSatisfaction type="서비스" text={serviceRating} />
       <TextDivider />
-      <FeedbackCard type="탑승" text={rideRating} />
+      <ExperienceSatisfaction type="탑승" text={rideRating} />
     </div>
   );
 };
 
-export default FeedbackGroup;
+export default ReviewProperty;
 
 const PassengerRegion = ({ regionName }: { regionName: string }) => {
   return (
@@ -36,12 +37,15 @@ const PassengerRegion = ({ regionName }: { regionName: string }) => {
   );
 };
 
-interface FeedbackCardProps {
-  type: FeedbackType;
-  text: FeedbackText;
+interface ExperienceSatisfactionProps {
+  type: ExperienceSatisfactionType;
+  text: ExperienceSatisfactionText;
 }
 
-const FeedbackCard = ({ type, text }: FeedbackCardProps) => {
+const ExperienceSatisfaction = ({
+  type,
+  text,
+}: ExperienceSatisfactionProps) => {
   return (
     <div className="flex items-center gap-4">
       <p className="text-12 font-500 leading-[160%] text-basic-grey-700">
@@ -54,10 +58,15 @@ const FeedbackCard = ({ type, text }: FeedbackCardProps) => {
   );
 };
 
-type FeedbackType = '서비스' | '탑승';
-type FeedbackText = '매우 불만족' | '불만족' | '보통' | '만족' | '매우 만족';
+type ExperienceSatisfactionType = '서비스' | '탑승';
+type ExperienceSatisfactionText =
+  | '매우 불만족'
+  | '불만족'
+  | '보통'
+  | '만족'
+  | '매우 만족';
 
-const FEEDBACK_TEXT_LIST: FeedbackText[] = [
+const EXPERIENCE_SATISFACTION_TEXT_LIST: ExperienceSatisfactionText[] = [
   '매우 불만족',
   '불만족',
   '보통',

--- a/src/types/review.type.ts
+++ b/src/types/review.type.ts
@@ -21,6 +21,8 @@ export const ReviewsViewEntitySchema = z
     userId: z.string(),
     userNickname: z.string(),
     userProfileImage: z.string().nullable(),
+    toDestinationRegionId: z.string().nullable(),
+    fromDestinationRegionId: z.string().nullable(),
     eventId: z.string(),
     eventName: z.string(),
     eventType: EventTypeEnum,


### PR DESCRIPTION
## 개요
00탑승객 | 서비스 만족도 | 탑승 만족도 api 반영되었습니다.
리뷰의 여백 조정되었습니다

## 변경사항
- ReviewsViewEntity 에 nullable한 칼럼이 추가되었습니다. toDestinationRegionId, fromDestinationRegionId
- FeedbackGroup 컴포넌트를 분리하였습니다. (이전엔 홈의 리뷰, 마이페이지 내 후기 확인하기, 리뷰 전체보기 3군데서 사용되고 있었음)
- FeedbackGroup 컴포넌트의 네이밍이 ReviewProperty로 변경되었습니다.


<img width="334" alt="Screenshot 2025-06-05 at 1 33 00 PM" src="https://github.com/user-attachments/assets/5a2b4f51-3885-417e-9d21-d8ab85846a8f" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).