### PR TITLE
fix: 리뷰 조회 시에 정렬 파라미터 적용

### DIFF
--- a/src/app/(home)/@bot/components/PromotionReviews.tsx
+++ b/src/app/(home)/@bot/components/PromotionReviews.tsx
@@ -10,9 +10,7 @@ import ReviewProperty from '@/components/review/ReviewProperty';
 export const revalidate = DEFAULT_SSG_REVALIDATE_TIME;
 
 const PromotionReview = async () => {
-  const paginatedReviews = await getReviewsWithPagination({
-    revalidate: DEFAULT_SSG_REVALIDATE_TIME,
-  });
+  const paginatedReviews = await getReviewsWithPagination();
 
   const top3 = paginatedReviews.reviews
     .slice(0, 10)

--- a/src/app/mypage/reviews/[reviewId]/components/ReviewListWithMyReview.tsx
+++ b/src/app/mypage/reviews/[reviewId]/components/ReviewListWithMyReview.tsx
@@ -18,29 +18,31 @@ interface Props {
 }
 
 const ReviewListWithMyReview = ({ reviewId }: Props) => {
-  const { data, fetchNextPage, isFetching, hasNextPage } =
-    useGetReviewsWithPagination();
-
   const [sort, setSort] = useState<ReviewSortType>('DATE_DESC');
-  const ref = useInfiniteScroll(fetchNextPage);
-  const reviews = data.reviews;
+  const {
+    data: reviewPages,
+    fetchNextPage,
+    isFetching,
+    hasNextPage,
+  } = useGetReviewsWithPagination({
+    orderBy: sort === 'DATE_DESC' ? undefined : 'rating',
+    additionalOrderOptions:
+      sort === 'DATE_DESC'
+        ? undefined
+        : sort === 'RATING_DESC'
+          ? 'DESC'
+          : 'ASC',
+  });
 
   const reviewListWithoutMyReview = useMemo(
-    () => reviews.filter((review) => review.reviewId !== reviewId),
-    [reviews, reviewId],
+    () =>
+      reviewPages?.pages
+        .flatMap((page) => page.reviews)
+        .filter((review) => review.reviewId !== reviewId),
+    [reviewPages, reviewId],
   );
 
-  const sortedReviews = useMemo(() => {
-    return reviewListWithoutMyReview.sort((a, b) => {
-      if (sort === 'RATING_ASC') {
-        return a.rating - b.rating;
-      }
-      if (sort === 'RATING_DESC') {
-        return b.rating - a.rating;
-      }
-      return b.createdAt.localeCompare(a.createdAt);
-    });
-  }, [sort, reviewListWithoutMyReview]);
+  const ref = useInfiniteScroll(fetchNextPage);
 
   return (
     <>
@@ -50,7 +52,7 @@ const ReviewListWithMyReview = ({ reviewId }: Props) => {
       <section className="mt-32 flex flex-col gap-16 px-16">
         <FilterButton sort={sort} onSort={setSort} />
         {reviewId && <MyReviewItem reviewId={reviewId} />}
-        {sortedReviews.map((review) => (
+        {reviewListWithoutMyReview.map((review) => (
           <ReviewItem key={review.reviewId} review={review} />
         ))}
         {!isFetching && hasNextPage && (

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -39,25 +39,31 @@ export const useGetUserReviews = () =>
   });
 
 interface GetReviewsWithPaginationOptions {
-  revalidate?: number;
   limit: number;
   page?: string;
   eventId?: string;
   userId?: string;
+  orderBy?: 'eventName' | 'userNickname' | 'rating';
+  additionalOrderOptions?: 'ASC' | 'DESC';
 }
 
 export const getReviewsWithPagination = async ({
   limit = DEFAULT_PAGINATION_LIMIT,
   page,
   eventId,
-  userId,
-  revalidate,
+  orderBy,
+  additionalOrderOptions,
 }: Partial<GetReviewsWithPaginationOptions> = {}) => {
-  const searchParams = toSearchParams({ limit, page, eventId, userId });
+  const searchParams = toSearchParams({
+    limit,
+    page,
+    eventId,
+    orderBy,
+    additionalOrderOptions,
+  });
   const res = await instance.get(
     `/v2/shuttle-operation/reviews?${searchParams.toString()}`,
     {
-      next: { revalidate },
       shape: withPagination({ reviews: ReviewsViewEntitySchema.array() }),
     },
   );
@@ -74,10 +80,6 @@ export const useGetReviewsWithPagination = (
     initialPageParam: undefined,
     initialData: { pages: [], pageParams: [] },
     getNextPageParam: (lastPage) => lastPage.nextPage,
-    select: (data) => ({
-      reviews: (data.pages ?? []).flatMap((page) => page.reviews),
-      totalCount: data.pages?.[0]?.totalCount ?? 0,
-    }),
   });
 
 export const getReview = async (reviewId: string) => {


### PR DESCRIPTION
## 개요

기존에 리뷰를 조회하고 프론트에서 정렬하던 방식을 api 파라미터로 정렬값을 보내 정렬된 데이터를 받아오는 방식으로 수정했습니다.
이로 페이지네이션 과정에서 정렬이 올바르게 되지 않던 부분을 수정했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).