### PR TITLE
feat: 마이페이지 예약상세내역에 다중 환불내역 반영

### DIFF
--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/Content.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/Content.tsx
@@ -17,6 +17,8 @@ import RefundSection from './sections/refund-section/RefundSection';
 import PrimaryCheckIcon from '../icons/icon-check-primary.svg';
 import GreyCheckIcon from '../icons/icon-check-grey.svg';
 import WrapperWithDivider from './WrapperWithDivider';
+import { calculateRefundFeeRate } from '@/utils/reservation.util';
+import { useMemo } from 'react';
 
 const TAXI_HUB_PREFIX = process.env.NEXT_PUBLIC_TAXI_HUB_NAME;
 
@@ -69,6 +71,14 @@ const Content = ({ reservation, payment, shuttleBus }: Props) => {
         hub.name?.includes(TAXI_HUB_PREFIX),
       ));
 
+  const refundCreatedAt = useMemo(() => {
+    return (
+      payment.refundRequests?.find(
+        (r) => r.refundReason === '자동 승인 환불 요청',
+      )?.refundAt ?? null
+    );
+  }, [payment.refundRequests]);
+
   return (
     <main className="grow pb-16">
       <Title progress={reservationProgress} />
@@ -116,6 +126,11 @@ const Content = ({ reservation, payment, shuttleBus }: Props) => {
             passengerCount={reservation.passengerCount}
             isCanceled={isCanceled}
             isHandySupported={handyStatus !== 'NOT_SUPPORTED'}
+            userCancellationFee={calculateRefundFeeRate(
+              reservation,
+              payment.createdAt,
+              refundCreatedAt,
+            )}
           />
         </WrapperWithDivider>
         <GuidelineSection />

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/PriceSection.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/PriceSection.tsx
@@ -1,4 +1,4 @@
-import { PaymentsViewEntity } from '@/types/payment.type';
+import { PaymentsViewEntity, RefundFeeRate } from '@/types/payment.type';
 import RegularPriceContent from './components/RegularPriceContent';
 import RefundPriceContent from './components/RefundPriceContent';
 
@@ -7,6 +7,7 @@ interface Props {
   passengerCount: number;
   isCanceled: boolean;
   isHandySupported: boolean;
+  userCancellationFee: RefundFeeRate | null;
 }
 
 const PriceSection = ({
@@ -14,12 +15,16 @@ const PriceSection = ({
   passengerCount,
   isCanceled,
   isHandySupported,
+  userCancellationFee,
 }: Props) => {
   return (
     <section className="px-16">
       <h3 className="pb-16 text-16 font-600">결제 정보</h3>
       {isCanceled ? (
-        <RefundPriceContent payment={payment} />
+        <RefundPriceContent
+          payment={payment}
+          userCancellationFee={userCancellationFee}
+        />
       ) : (
         <RegularPriceContent
           payment={payment}

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/PriceSection.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/PriceSection.tsx
@@ -15,12 +15,11 @@ const PriceSection = ({
   isCanceled,
   isHandySupported,
 }: Props) => {
-  const refundRequest = payment.refundRequests?.[0];
   return (
     <section className="px-16">
       <h3 className="pb-16 text-16 font-600">결제 정보</h3>
-      {isCanceled && refundRequest ? (
-        <RefundPriceContent payment={payment} refundRequest={refundRequest} />
+      {isCanceled ? (
+        <RefundPriceContent payment={payment} />
       ) : (
         <RegularPriceContent
           payment={payment}

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RefundPriceContent.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RefundPriceContent.tsx
@@ -1,11 +1,12 @@
-import { PaymentsViewEntity } from '@/types/payment.type';
+import { PaymentsViewEntity, RefundFeeRate } from '@/types/payment.type';
 import RefundRequestList from './RefundRequestList';
 
 interface Props {
   payment: PaymentsViewEntity;
+  userCancellationFee: RefundFeeRate | null;
 }
 
-const RefundPriceContent = ({ payment }: Props) => {
+const RefundPriceContent = ({ payment, userCancellationFee }: Props) => {
   const paymentAmount = payment.paymentAmount;
 
   return (
@@ -16,7 +17,10 @@ const RefundPriceContent = ({ payment }: Props) => {
           {paymentAmount.toLocaleString()}원
         </span>
       </li>
-      <RefundRequestList refundRequests={payment.refundRequests} />
+      <RefundRequestList
+        refundRequests={payment.refundRequests}
+        userCancellationFee={userCancellationFee}
+      />
     </div>
   );
 };

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RefundPriceContent.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RefundPriceContent.tsx
@@ -1,57 +1,22 @@
-import {
-  PaymentsViewEntity,
-  RefundRequestsInPaymentsViewEntity,
-} from '@/types/payment.type';
-import ArrowDownwardTipRightIcon from '../icons/arrow-downward-tip-right.svg';
-import { dateString } from '@/utils/dateString.util';
+import { PaymentsViewEntity } from '@/types/payment.type';
+import RefundRequestList from './RefundRequestList';
 
 interface Props {
   payment: PaymentsViewEntity;
-  refundRequest: RefundRequestsInPaymentsViewEntity;
 }
 
-const RefundPriceContent = ({ payment, refundRequest }: Props) => {
+const RefundPriceContent = ({ payment }: Props) => {
   const paymentAmount = payment.paymentAmount;
-  const refundAmount = refundRequest.refundAmount;
-  const refundFee = paymentAmount - refundAmount;
-
-  const refundAcceptedAt = dateString(refundRequest.refundAt, {
-    showYear: true,
-    showDate: true,
-    showWeekday: false,
-    showTime: true,
-  });
 
   return (
     <div className="flex flex-col gap-8">
       <li className="flex h-[22px] w-full items-center justify-between">
-        <span className="text-14 font-600">결제 취소</span>
+        <span className="text-14 font-600">결제 총액</span>
         <span className="text-14 font-600">
           {paymentAmount.toLocaleString()}원
         </span>
       </li>
-      <li className="flex h-[22px] w-full items-center justify-between">
-        <span className="flex items-center gap-4 text-14 font-400 text-basic-red-300">
-          <ArrowDownwardTipRightIcon />
-          취소 수수료
-        </span>
-        <span className="text-14 font-400 text-basic-red-300">
-          {refundFee.toLocaleString()}원
-        </span>
-      </li>
-      <div className="my-16 h-[1px] w-full bg-basic-grey-100" />
-      <li className="flex h-[22px] w-full items-center justify-between">
-        <span className="text-14 font-600">환불 총액</span>
-        <span className="text-14 font-600 text-basic-red-400">
-          {refundAmount.toLocaleString()}원
-        </span>
-      </li>
-      <li className="flex h-[22px] w-full items-center justify-between">
-        <span className="flex items-center gap-4 text-14 font-400 text-basic-grey-500">
-          <ArrowDownwardTipRightIcon />
-          환불 일시 | {refundAcceptedAt}
-        </span>
-      </li>
+      <RefundRequestList refundRequests={payment.refundRequests} />
     </div>
   );
 };

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RefundRequestList.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RefundRequestList.tsx
@@ -1,12 +1,17 @@
-import { RefundRequestsInPaymentsViewEntity } from '@/types/payment.type';
+import {
+  RefundFeeRate,
+  RefundRequestsInPaymentsViewEntity,
+} from '@/types/payment.type';
 import ArrowDownwardTipRightIcon from '../icons/arrow-downward-tip-right.svg';
 import { dateString } from '@/utils/dateString.util';
+import { USER_CANCELLATION_FEE_REASON } from '@/constants/common';
 
 interface Props {
   refundRequests: RefundRequestsInPaymentsViewEntity[] | null;
+  userCancellationFee: RefundFeeRate | null;
 }
 
-const RefundRequestList = ({ refundRequests }: Props) => {
+const RefundRequestList = ({ refundRequests, userCancellationFee }: Props) => {
   const totalRefundAmount = refundRequests?.reduce((acc, curr) => {
     return acc + curr.refundAmount;
   }, 0);
@@ -39,6 +44,9 @@ const RefundRequestList = ({ refundRequests }: Props) => {
               <span className="flex items-center gap-4">
                 <ArrowDownwardTipRightIcon />
                 환불 사유 | {refundRequest.refundReason}
+                {refundRequest.refundReason === USER_CANCELLATION_FEE_REASON &&
+                  userCancellationFee &&
+                  ` (${'취소 수수료' + userCancellationFee + '제외'})`}
               </span>
               <span>{refundRequest.refundAmount.toLocaleString()}원</span>
             </div>

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RefundRequestList.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RefundRequestList.tsx
@@ -14,6 +14,14 @@ const RefundRequestList = ({ refundRequests }: Props) => {
   if (!refundRequests || refundRequests.length === 0) return;
   return (
     <>
+      <li className="flex h-[22px] w-full items-center justify-between">
+        <span className="flex items-center gap-4 text-14 font-400 text-basic-red-300">
+          <ArrowDownwardTipRightIcon /> 결제 취소
+        </span>
+        <span className="text-14 font-400 text-basic-red-300">
+          {totalRefundAmount?.toLocaleString()}원
+        </span>
+      </li>
       <div className="my-16 h-[1px] w-full bg-basic-grey-100" />
       <div className="flex h-[22px] w-full items-center justify-between">
         <span className="text-14 font-600">환불 총액</span>

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RefundRequestList.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RefundRequestList.tsx
@@ -1,0 +1,54 @@
+import { RefundRequestsInPaymentsViewEntity } from '@/types/payment.type';
+import ArrowDownwardTipRightIcon from '../icons/arrow-downward-tip-right.svg';
+import { dateString } from '@/utils/dateString.util';
+
+interface Props {
+  refundRequests: RefundRequestsInPaymentsViewEntity[] | null;
+}
+
+const RefundRequestList = ({ refundRequests }: Props) => {
+  const totalRefundAmount = refundRequests?.reduce((acc, curr) => {
+    return acc + curr.refundAmount;
+  }, 0);
+
+  if (!refundRequests || refundRequests.length === 0) return;
+  return (
+    <>
+      <div className="my-16 h-[1px] w-full bg-basic-grey-100" />
+      <div className="flex h-[22px] w-full items-center justify-between">
+        <span className="text-14 font-600">환불 총액</span>
+        <span className="text-14 font-600 text-basic-red-400">
+          {totalRefundAmount?.toLocaleString()}원
+        </span>
+      </div>
+      <ul className="mt-8 flex flex-col gap-8">
+        {refundRequests.map((refundRequest) => (
+          <li
+            className="flex flex-col gap-4 text-14 font-400 text-basic-grey-500"
+            key={refundRequest.refundRequestId}
+          >
+            <div className="flex w-full items-center justify-between">
+              <span className="flex items-center gap-4">
+                <ArrowDownwardTipRightIcon />
+                환불 사유 | {refundRequest.refundReason}
+              </span>
+              <span>{refundRequest.refundAmount.toLocaleString()}원</span>
+            </div>
+            <span className="flex items-center gap-4 pl-16 text-14 font-400 text-basic-grey-500">
+              <ArrowDownwardTipRightIcon />
+              환불 일시 |{' '}
+              {dateString(refundRequest.refundAt, {
+                showYear: true,
+                showDate: true,
+                showWeekday: false,
+                showTime: true,
+              })}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+export default RefundRequestList;

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RegularPriceContent.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RegularPriceContent.tsx
@@ -18,6 +18,8 @@ const RegularPriceContent = ({
   const regularPrice = payment.principalAmount / passengerCount;
   const totalEarlybirdDiscountAmount = payment.earlybirdDiscountAmount;
   const totalCouponDiscountAmount = payment.couponDiscountAmount;
+  const hasRefundRequests =
+    payment?.refundRequests && payment.refundRequests.length > 0;
 
   const paymentAt = dateString(payment.createdAt, {
     showYear: true,
@@ -29,8 +31,14 @@ const RegularPriceContent = ({
   return (
     <div className="flex flex-col gap-8">
       <li className="flex h-[22px] w-full items-center justify-between">
-        <span className="text-14 font-600">결제 금액</span>
-        <span className="text-14 font-600 text-brand-primary-400">
+        <span className="text-14 font-600">
+          결제 {hasRefundRequests ? '총액' : '금액'}
+        </span>
+        <span
+          className={`text-14 font-600 ${
+            !hasRefundRequests && 'text-brand-primary-400'
+          }`}
+        >
           {paymentAmount.toLocaleString()}원
         </span>
       </li>

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RegularPriceContent.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RegularPriceContent.tsx
@@ -1,6 +1,7 @@
 import { PaymentsViewEntity } from '@/types/payment.type';
 import ArrowDownwardTipRightIcon from '../icons/arrow-downward-tip-right.svg';
 import { dateString } from '@/utils/dateString.util';
+import RefundRequestList from './RefundRequestList';
 
 interface Props {
   payment: PaymentsViewEntity;
@@ -77,6 +78,7 @@ const RegularPriceContent = ({
           않습니다.
         </div>
       )}
+      <RefundRequestList refundRequests={payment.refundRequests} />
     </div>
   );
 };

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RegularPriceContent.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/price-section/components/RegularPriceContent.tsx
@@ -86,7 +86,10 @@ const RegularPriceContent = ({
           않습니다.
         </div>
       )}
-      <RefundRequestList refundRequests={payment.refundRequests} />
+      <RefundRequestList
+        refundRequests={payment.refundRequests}
+        userCancellationFee={null}
+      />
     </div>
   );
 };

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/components/CancelBottomSheet.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/components/CancelBottomSheet.tsx
@@ -6,12 +6,9 @@ import { BottomSheetRefs } from '@/hooks/useBottomSheet';
 import { useMemo } from 'react';
 import { usePostRefund } from '@/services/payment.service';
 import { ReservationsViewEntity } from '@/types/reservation.type';
-import {
-  calculateRefundFee,
-  calculateRefundFeeRate,
-  getIsRefundable,
-} from '@/utils/reservation.util';
+import { calculateRefundFee, getIsRefundable } from '@/utils/reservation.util';
 import { useRouter } from 'next/navigation';
+import { USER_CANCELLATION_FEE_REASON } from '@/constants/common';
 
 interface Props extends BottomSheetRefs {
   reservation: ReservationsViewEntity | null;
@@ -32,18 +29,13 @@ const CancelBottomSheet = ({
     },
   });
 
-  const refundFeeRate = useMemo(
-    () => calculateRefundFeeRate(reservation),
-    [reservation],
-  );
-
   const handleSubmit = () => {
     if (!reservation || !reservation.paymentId) {
       return;
     }
     postRefund({
       paymentId: reservation.paymentId,
-      refundReason: `자동 승인 환불 요청 ${refundFeeRate ? `(수수료 ${refundFeeRate} 제외)` : ''}`,
+      refundReason: USER_CANCELLATION_FEE_REASON,
     });
   };
 

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/components/CancelBottomSheet.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/components/CancelBottomSheet.tsx
@@ -6,7 +6,11 @@ import { BottomSheetRefs } from '@/hooks/useBottomSheet';
 import { useMemo } from 'react';
 import { usePostRefund } from '@/services/payment.service';
 import { ReservationsViewEntity } from '@/types/reservation.type';
-import { calculateRefundFee, getIsRefundable } from '@/utils/reservation.util';
+import {
+  calculateRefundFee,
+  calculateRefundFeeRate,
+  getIsRefundable,
+} from '@/utils/reservation.util';
 import { useRouter } from 'next/navigation';
 
 interface Props extends BottomSheetRefs {
@@ -28,13 +32,18 @@ const CancelBottomSheet = ({
     },
   });
 
+  const refundFeeRate = useMemo(
+    () => calculateRefundFeeRate(reservation),
+    [reservation],
+  );
+
   const handleSubmit = () => {
     if (!reservation || !reservation.paymentId) {
       return;
     }
     postRefund({
       paymentId: reservation.paymentId,
-      refundReason: '자동 승인 환불 요청',
+      refundReason: `자동 승인 환불 요청 ${refundFeeRate ? `(수수료 ${refundFeeRate} 제외)` : ''}`,
     });
   };
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -11,3 +11,5 @@ export const LONG_QUERY_STALE_TIME = 5 * 60 * 1000; // 5분
 export const MAX_PASSENGER_COUNT = 9; // 한번에 예약 가능한 최대 인원 수 (9명)
 
 export const MAX_HANDY_DISCOUNT_AMOUNT = 40000; // 핸디 할인 최대 금액 (4만원)
+
+export const USER_CANCELLATION_FEE_REASON = '자동 승인 환불 요청';

--- a/src/types/payment.type.ts
+++ b/src/types/payment.type.ts
@@ -6,6 +6,24 @@ import {
   ReservationStatusEnum,
 } from './reservation.type';
 
+// ----- ENUM -----
+
+export const REFUND_FEE_RATE = {
+  NO_FEE: '',
+  TWENTY_FIVE_PERCENT: '25%',
+  FIFTY_PERCENT: '50%',
+  HUNDRED_PERCENT: '100%',
+} as const;
+
+export const RefundFeeRateEnum = z.enum([
+  REFUND_FEE_RATE.NO_FEE,
+  REFUND_FEE_RATE.TWENTY_FIVE_PERCENT,
+  REFUND_FEE_RATE.FIFTY_PERCENT,
+  REFUND_FEE_RATE.HUNDRED_PERCENT,
+]);
+
+export type RefundFeeRate = z.infer<typeof RefundFeeRateEnum>;
+
 // ----- GET -----
 
 export const RefundRequestsInPaymentsViewEntitySchema = z

--- a/src/utils/reservation.util.ts
+++ b/src/utils/reservation.util.ts
@@ -105,15 +105,16 @@ export const getIsRefundable = (reservation: ReservationsViewEntity | null) => {
 
 export const calculateRefundFeeRate = (
   reservation: ReservationsViewEntity | null,
+  paymentCreatedAt: string,
+  refundCreatedAt: string | null,
 ): RefundFeeRate | null => {
-  if (!reservation) {
+  if (!reservation || !refundCreatedAt) {
     return null;
   }
-  // 24시간 이내 전액 환불
-  const nowTime = dayjs().tz();
-  const paymentTime = dayjs(reservation.paymentCreatedAt).tz();
+  const paymentTime = dayjs(paymentCreatedAt).tz();
+  const refundTime = dayjs(refundCreatedAt).tz();
 
-  if (nowTime.diff(paymentTime, 'hours') <= 24) {
+  if (refundTime.diff(paymentTime, 'hours') <= 24) {
     return REFUND_FEE_RATE.NO_FEE;
   }
 
@@ -130,9 +131,9 @@ export const calculateRefundFeeRate = (
     return null;
   }
   const boardingDate = boardingTime.startOf('day');
-  const nowDate = dayjs().tz().startOf('day');
+  const refundDate = refundTime.startOf('day');
 
-  const dDay = boardingDate.diff(nowDate, 'day');
+  const dDay = boardingDate.diff(refundDate, 'day');
 
   let refundFeeRate: RefundFeeRate = REFUND_FEE_RATE.NO_FEE;
 

--- a/src/utils/reservation.util.ts
+++ b/src/utils/reservation.util.ts
@@ -1,3 +1,4 @@
+import { REFUND_FEE_RATE, RefundFeeRate } from '@/types/payment.type';
 import { ReservationsViewEntity } from '@/types/reservation.type';
 import {
   ShuttleRouteHubsInShuttleRoutesViewEntity,
@@ -100,4 +101,50 @@ export const getIsRefundable = (reservation: ReservationsViewEntity | null) => {
     return false;
   }
   return refundFee !== reservation.paymentAmount;
+};
+
+export const calculateRefundFeeRate = (
+  reservation: ReservationsViewEntity | null,
+): RefundFeeRate | null => {
+  if (!reservation) {
+    return null;
+  }
+  // 24시간 이내 전액 환불
+  const nowTime = dayjs().tz();
+  const paymentTime = dayjs(reservation.paymentCreatedAt).tz();
+
+  if (nowTime.diff(paymentTime, 'hours') <= 24) {
+    return REFUND_FEE_RATE.NO_FEE;
+  }
+
+  const boardingTime = getBoardingTime({
+    tripType: reservation.type,
+    toDestinationShuttleRouteHubs:
+      reservation.shuttleRoute.toDestinationShuttleRouteHubs ?? [],
+    fromDestinationShuttleRouteHubs:
+      reservation.shuttleRoute.fromDestinationShuttleRouteHubs ?? [],
+    toDestinationShuttleRouteHubId:
+      reservation.toDestinationShuttleRouteHubId ?? '',
+  });
+  if (!boardingTime) {
+    return null;
+  }
+  const boardingDate = boardingTime.startOf('day');
+  const nowDate = dayjs().tz().startOf('day');
+
+  const dDay = boardingDate.diff(nowDate, 'day');
+
+  let refundFeeRate: RefundFeeRate = REFUND_FEE_RATE.NO_FEE;
+
+  if (dDay >= 8) {
+    refundFeeRate = REFUND_FEE_RATE.NO_FEE;
+  } else if (dDay === 7) {
+    refundFeeRate = REFUND_FEE_RATE.TWENTY_FIVE_PERCENT;
+  } else if (dDay === 6) {
+    refundFeeRate = REFUND_FEE_RATE.FIFTY_PERCENT;
+  } else {
+    refundFeeRate = REFUND_FEE_RATE.HUNDRED_PERCENT;
+  }
+
+  return refundFeeRate;
 };


### PR DESCRIPTION
## 개요
마이페이지 예약상세내역에 다중 환불내역을 반영합니다.

## 변경사항
- 어드민 환불 기능이 추가됨에 따라서, 환불 사유와 다중 환불내역을 보여줍니다.
- 마이페이지 - 예약 상세 내역에서 '자동 환불 승인 요청'의 메세지가 존재하고, 취소 수수료가 발생했다면 (수수료 00% 제외) 문구를 함께 보여줍니다. 
  - 5일전 수수료 없음 : 추가 문구 없음
  - 6일전 25% 수수료 : (수수료 25% 제외)
  - 7일전 50% 수수료 : (수수료 50% 제외)
  - 8일전 100% 수수료 : (수수료 100% 제외)
- 소소한 ui 변경 반영

## 참고사항
  - 운영팀에서 요구한 행사 취소, 무산의 상태는 반영할 수 없었습니다. 예약취소 상태에서 행사 취소인지, 무산인지, 유저가 스스로 취소한 것인지 현재로서는 알 수 있는 방법이 없기 때문입니다.
  - 상태를 추가하지 않아도 행사취소, 무산의 상태도 예약 취소상태상태에 포함되어있다고 생각하면 무방합니다.


## 백엔드와함께 테스트 필요
수수료 25% 기간에서 환불 (7일전)
-> 프론트는 25환불이라고 사전안내 및 마이페이지에서도 정상적으로 보임. 
-> 그러나 실제로 온 환불금액이 100% 환불된 금액이 왔음.

8일전(100%), 6일전(50%) 에서는 정상적으로 환불됨.

<img width="445" alt="Screenshot 2025-06-18 at 2 49 06 PM" src="https://github.com/user-attachments/assets/3dc20cd6-ea8a-4dc8-86b8-fb58808bc46f" />

### 예약완료
| 예약완료 | 예약완료 및 환불내역 | 예약취소 |
|--------|--------|--------|
| <img width="406" alt="Screenshot 2025-06-13 at 6 09 55 PM" src="https://github.com/user-attachments/assets/9473d88f-b531-4f9a-a3b8-a667d975e268" /> | <img width="365" alt="Screenshot 2025-06-13 at 6 10 41 PM" src="https://github.com/user-attachments/assets/c247f5df-f0d0-45ee-8d21-7b6711079991" /> | <img width="363" alt="Screenshot 2025-06-13 at 6 12 11 PM" src="https://github.com/user-attachments/assets/a24090ef-7391-48b4-b683-03fcb1a22cb6" />

*예약이 취소되지 않고도 ADMIN_ADJUSTMENT, PAYBACK으로 환불될 수 있음 [관련 링크](https://github.com/HandyBus/handybus-admin-web-latest/pull/217)

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).