### PR TITLE
fix: 핸디팟 정류장일때 마이페이지 예약상세에서 셔틀 운영 100% 문구 가리기

### DIFF
--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/Content.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/Content.tsx
@@ -82,6 +82,7 @@ const Content = ({ reservation, payment, shuttleBus }: Props) => {
               isOpenChatLinkCreated={isOpenChatLinkCreated}
               handyStatus={handyStatus}
               shuttleBus={shuttleBus}
+              isTaxiRoute={!!isTaxiRoute}
             />
           </WrapperWithDivider>
         )}

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-progress-section/ShuttleProgressSection.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-progress-section/ShuttleProgressSection.tsx
@@ -13,6 +13,7 @@ interface Props {
   isOpenChatLinkCreated: boolean;
   handyStatus: HandyStatus;
   shuttleBus: ShuttleBusesViewEntity | null | undefined;
+  isTaxiRoute: boolean;
 }
 
 const ShuttleProgressSection = ({
@@ -21,6 +22,7 @@ const ShuttleProgressSection = ({
   isOpenChatLinkCreated,
   handyStatus,
   shuttleBus,
+  isTaxiRoute,
 }: Props) => {
   const isHandy = handyStatus === 'ACCEPTED';
 
@@ -125,7 +127,8 @@ const ShuttleProgressSection = ({
           <p className="pb-8 text-14 font-500 text-basic-grey-700">
             {descriptionText}
           </p>
-          {reservationProgress !== 'shuttleEnded' &&
+          {!isTaxiRoute &&
+            reservationProgress !== 'shuttleEnded' &&
             reservationProgress !== 'reservationCanceled' && (
               <p className="flex items-center gap-[2px]">
                 <CheckIcon />


### PR DESCRIPTION
## 개요
핸디팟정류장일때 마이페이지 예약상세에서 예약한 셔틀은 100% 운행되니 안심하세요. 문구를 가립니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).