### PR TITLE
design: 일자별 수요조사 모집 중 버튼 ui및 텍스트 변경

### DIFF
--- a/src/app/event/[eventId]/components/steps/common-steps/CommonDateStep.tsx
+++ b/src/app/event/[eventId]/components/steps/common-steps/CommonDateStep.tsx
@@ -61,12 +61,12 @@ const CommonDateStep = ({ toNextStep, phase }: Props) => {
             </button>
             {isDemandOpenAndReservationClosed && (
               <Button
-                variant="secondary"
+                variant="primary"
                 size="small"
                 className="absolute right-0 top-1/2 w-100 -translate-y-1/2"
                 onClick={() => handleDateClick(dailyEvent)}
               >
-                전지역 수요조사 중
+                수요조사 참여하기
               </Button>
             )}
           </div>


### PR DESCRIPTION
## 개요
일자별 수요조사 모집 중 버튼 ui및 텍스트 변경

## 변경사항
요청사항 : jujeon 준성님 이거 QA할 때 피그마에 넣어놓았던 요청사항인데 반영이 안된 것 같아요..! 
전지역 수요조사 중일 때 수요조사 참여 버튼 변경 요청드려도될까요? 기존 버튼은 버튼보다 태그처럼 보이고 액션 트리거도 잘 안되는 같아서요오 🥲

| 변경전 | 변경후 |
|--------|--------|
| <img width="386" alt="Screenshot 2025-06-17 at 3 46 36 PM" src="https://github.com/user-attachments/assets/7317a41d-3865-4ecf-93ee-a85fff76147d" /> | <img width="409" alt="Screenshot 2025-06-17 at 3 41 18 PM" src="https://github.com/user-attachments/assets/77bf8eb8-3003-4ea4-bba8-0b95839f9fdc" /> | 

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).