### PR TITLE
hotfix: 예약 정류장 바텀시트에서 수요조사가 열렸을 때에만 요청하기 버튼 표시

### DIFF
--- a/src/app/event/[eventId]/components/steps/reservation-steps/ReservationHubsStep.tsx
+++ b/src/app/event/[eventId]/components/steps/reservation-steps/ReservationHubsStep.tsx
@@ -102,6 +102,8 @@ const ReservationHubsStep = ({
       );
   }, [gungusWithHubs, recentlyViewedHubId]);
 
+  const isDemandPossibie = dailyEvent.status === 'OPEN';
+
   return (
     <section>
       {recentlyViewedPossibleHubs && (
@@ -118,7 +120,7 @@ const ReservationHubsStep = ({
         </div>
       )}
       <div>
-        {gungusWithHubs.map((gunguWithHubs) => (
+        {gungusWithHubs.map((gunguWithHubs, index) => (
           <article key={gunguWithHubs.gungu}>
             <div className="mb-4 flex h-[26px] items-center gap-[2px]">
               <PinIcon />
@@ -136,26 +138,30 @@ const ReservationHubsStep = ({
                 />
               ))}
             </ul>
-            <div className="my-12 h-[1px] w-full bg-basic-grey-100" />
+            {index !== gungusWithHubs.length - 1 && (
+              <div className="my-12 h-[1px] w-full bg-basic-grey-100" />
+            )}
           </article>
         ))}
       </div>
-      <div className="flex items-center justify-between gap-8 pb-12">
-        <div className="flex h-[26px] items-center gap-4">
-          <span className="text-16 font-600 text-basic-grey-700">
-            찾는 정류장이 없나요?
-          </span>
-          <Tooltip content="원하는 지역이 보이지 않는다면, 해당 정류장은 수요조사가 진행 중이에요. 셔틀이 열릴 수 있도록 수요조사에 참여해 보세요." />
+      {isDemandPossibie && (
+        <div className="flex items-center justify-between gap-8 pb-12">
+          <div className="flex h-[26px] items-center gap-4">
+            <span className="text-16 font-600 text-basic-grey-700">
+              찾는 정류장이 없나요?
+            </span>
+            <Tooltip content="원하는 지역이 보이지 않는다면, 해당 정류장은 수요조사가 진행 중이에요. 셔틀이 열릴 수 있도록 수요조사에 참여해 보세요." />
+          </div>
+          <Button
+            onClick={toDemandHubsStep}
+            variant="tertiary"
+            size="small"
+            type="button"
+          >
+            요청하기
+          </Button>
         </div>
-        <Button
-          onClick={toDemandHubsStep}
-          variant="tertiary"
-          size="small"
-          type="button"
-        >
-          요청하기
-        </Button>
-      </div>
+      )}
     </section>
   );
 };


### PR DESCRIPTION
## 개요

행사 상세 페이지에서 예약 정류장을 보여주는 단계의 바텀시트에서 수요조사가 가능할 때에만 요청하기 섹션이 보이도록 처리했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).