### PR TITLE
fix: 핸디팟 정류장을 수요조사 단계에서 최근에 본 정류장에 뜨지 않도록 처리

### DIFF
--- a/src/app/event/[eventId]/components/steps/demand-steps/DemandHubsStep.tsx
+++ b/src/app/event/[eventId]/components/steps/demand-steps/DemandHubsStep.tsx
@@ -104,9 +104,13 @@ const DemandHubsStep = ({ toNextStep }: Props) => {
 
   const recentlyViewedHubId = getRecentlyViewedHubId();
   const recentlyViewedHub = useMemo(() => {
-    return regionsWithHubsPages?.pages?.[0]?.regionHubs.find(
+    const hub = regionsWithHubsPages?.pages?.[0]?.regionHubs.find(
       (hub) => hub.regionHubId === recentlyViewedHubId,
     );
+    if (hub?.name.includes(process.env.NEXT_PUBLIC_TAXI_HUB_NAME ?? '')) {
+      return null;
+    }
+    return hub;
   }, [regionsWithHubsPages, recentlyViewedHubId]);
   const isUserDemandAvailableForRecentlyViewedHub = useMemo(() => {
     if (!recentlyViewedHub || !event) {

--- a/src/app/event/[eventId]/components/steps/reservation-steps/ReservationHubsStep.tsx
+++ b/src/app/event/[eventId]/components/steps/reservation-steps/ReservationHubsStep.tsx
@@ -138,7 +138,7 @@ const ReservationHubsStep = ({
                 />
               ))}
             </ul>
-            {index !== gungusWithHubs.length - 1 && (
+            {(index !== gungusWithHubs.length - 1 || isDemandPossible) && (
               <div className="my-12 h-[1px] w-full bg-basic-grey-100" />
             )}
           </article>

--- a/src/app/event/[eventId]/components/steps/reservation-steps/ReservationHubsStep.tsx
+++ b/src/app/event/[eventId]/components/steps/reservation-steps/ReservationHubsStep.tsx
@@ -102,7 +102,7 @@ const ReservationHubsStep = ({
       );
   }, [gungusWithHubs, recentlyViewedHubId]);
 
-  const isDemandPossibie = dailyEvent.status === 'OPEN';
+  const isDemandPossible = dailyEvent.status === 'OPEN';
 
   return (
     <section>
@@ -144,7 +144,7 @@ const ReservationHubsStep = ({
           </article>
         ))}
       </div>
-      {isDemandPossibie && (
+      {isDemandPossible && (
         <div className="flex items-center justify-between gap-8 pb-12">
           <div className="flex h-[26px] items-center gap-4">
             <span className="text-16 font-600 text-basic-grey-700">


### PR DESCRIPTION
## 개요

핸디팟 정류장이 수요조사 단게에서 최근에 본 정류장에 뜨지 않도록 수정했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).