### PR TITLE
feat: 행사의 수요조사 수를 보여주는 단위 수정

### DIFF
--- a/src/app/event/[eventId]/components/steps/demand-steps/DemandHubsStep.tsx
+++ b/src/app/event/[eventId]/components/steps/demand-steps/DemandHubsStep.tsx
@@ -178,7 +178,7 @@ const DemandHubsStep = ({ toNextStep }: Props) => {
                           : 'text-basic-grey-500'
                       }`}
                     >
-                      {gunguWithHubs.demandCount}명이 요청했어요
+                      {/* {gunguWithHubs.demandCount}명이 요청했어요 */}
                     </span>
                   )}
                 </p>


### PR DESCRIPTION
## 개요

기존에 시군구 단위로 보여지던 수요조사 수를 숨기고 일자 단위로 보여지도록 수정했습니다.

## 변경사항

<img width="803" alt="스크린샷 2025-06-26 오후 4 41 43" src="https://github.com/user-attachments/assets/d803fe37-ceac-49bd-b427-575f31eb56ef" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).