### PR TITLE
fix: 핸디팟 정류장일때 지도 클릭시 404 페이지 이슈

### DIFF
--- a/src/app/event/[eventId]/components/shuttle-route-detail-view/components/KakaoMap.tsx
+++ b/src/app/event/[eventId]/components/shuttle-route-detail-view/components/KakaoMap.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { TAXI_HUB_PREFIX } from '@/utils/taxiRoute.util';
 import { useEffect, useRef } from 'react';
 
 interface Props {
@@ -51,6 +52,11 @@ const KakaoMap = ({
     window.kakao.maps.load(initializeMap);
   }, [mapRef, isKakaoMapScriptLoaded]);
 
+  // NOTE: 핸디팟인 경우 임시 처리
+  const placeNameWithException = placeName.startsWith(TAXI_HUB_PREFIX ?? '')
+    ? `핸디팟 ${placeName.split(TAXI_HUB_PREFIX ?? '')[1]} 지역`
+    : placeName;
+
   return (
     <div
       ref={mapRef}
@@ -58,7 +64,7 @@ const KakaoMap = ({
       onClick={() => {
         if (typeof window !== 'undefined') {
           window.open(
-            `https://map.kakao.com/link/map/${placeName},${latitude},${longitude}`,
+            `https://map.kakao.com/link/map/${placeNameWithException},${latitude},${longitude}`,
             '_blank',
             'noopener,noreferrer',
           );


### PR DESCRIPTION
## 개요
행사 노선 보기에서 [집앞하차] 접두사가 붙은 정류장의 지도를 클릭했을때 404 페이지가 뜨던 이슈를 임시 조치하였습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).