### PR TITLE
fix: 노선 방향에 따라 hub id 빈 값으로 처리하여 예약 생성

### DIFF
--- a/src/app/event/[eventId]/dailyevent/[dailyEventId]/route/[shuttleRouteId]/payment/components/Content.tsx
+++ b/src/app/event/[eventId]/dailyevent/[dailyEventId]/route/[shuttleRouteId]/payment/components/Content.tsx
@@ -79,8 +79,14 @@ const Content = ({
       const parsedFormValues = {
         shuttleRouteId: shuttleRoute.shuttleRouteId,
         type: tripType,
-        toDestinationShuttleRouteHubId: toDestinationHubId ?? undefined,
-        fromDestinationShuttleRouteHubId: fromDestinationHubId ?? undefined,
+        toDestinationShuttleRouteHubId:
+          tripType === 'ROUND_TRIP' || tripType === 'TO_DESTINATION'
+            ? (toDestinationHubId ?? undefined)
+            : undefined,
+        fromDestinationShuttleRouteHubId:
+          tripType === 'ROUND_TRIP' || tripType === 'FROM_DESTINATION'
+            ? (fromDestinationHubId ?? undefined)
+            : undefined,
         isSupportingHandy: isHandyApplied,
         passengerCount,
       };


### PR DESCRIPTION
## 개요

결제 단계에서 노선 방향에 따라 hub id를 올바르게 처리하여 예약이 생성되도록 수정했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).