### PR TITLE
feat: 전체 행사 필터 추가 및 스포츠 타입 반영

### DIFF
--- a/src/app/(home)/@event/components/RecommendedEventCard.tsx
+++ b/src/app/(home)/@event/components/RecommendedEventCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Chip from '@/components/chips/Chip';
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   EventType,
   EventTypeEnum,
@@ -12,32 +12,39 @@ import RecommendedEventSwiperView from './RecommendedEventSwiperView';
 import CardSection from './CardSection';
 import Empty from '@/app/event/components/Empty';
 
+type EventTypeWithAll = EventType | 'ALL';
+
 interface Props {
   events: EventWithRoutesViewEntity[] | null | undefined;
 }
 
 const RecommendedEventCard = ({ events }: Props) => {
-  const [type, setType] = useState<EventType>('CONCERT');
+  const [type, setType] = useState<EventTypeWithAll>('ALL');
 
   // 각 이벤트 타입별로 이벤트가 있는지 확인
   const availableEventTypes = EventTypeEnum.options.filter((eventType) =>
     events?.some((event) => event.eventType === eventType),
   );
 
-  // 데이터가 로드되고 현재 선택된 타입의 이벤트가 없으면 첫 번째 사용 가능한 타입으로 변경
-  useEffect(() => {
-    if (availableEventTypes.length > 0 && !availableEventTypes.includes(type)) {
-      setType(availableEventTypes[0]);
+  const filteredEvents = useMemo(() => {
+    if (type === 'ALL') {
+      return events;
     }
-  }, [availableEventTypes, type]);
-
-  const filteredEvents = events?.filter((event) => event.eventType === type);
+    return events?.filter((event) => event.eventType === type);
+  }, [events, type]);
 
   return (
     <section>
       <CardSection richTitle={`이달의 추천 행사`} showMore="/event">
         {availableEventTypes.length > 1 && (
           <div className="flex gap-8 pb-16">
+            <Chip
+              key={'ALL'}
+              onClick={() => setType('ALL')}
+              isSelected={type === 'ALL'}
+            >
+              전체
+            </Chip>
             {availableEventTypes.map((eventType) => (
               <Chip
                 key={eventType}

--- a/src/app/event/components/FilterBar.tsx
+++ b/src/app/event/components/FilterBar.tsx
@@ -2,12 +2,12 @@
 
 import Chip from '@/components/chips/Chip';
 import FilterButton from './FilterButton';
-import { EventType } from '@/types/event.type';
 import { EventSortType } from '@/app/event/event.const';
+import { EventTypeWithAll } from '../page';
 
 interface FilterBarProps {
-  type: EventType;
-  setType: (type: EventType) => void;
+  type: EventTypeWithAll;
+  setType: (type: EventTypeWithAll) => void;
   sort: EventSortType;
   onSort: (sort: EventSortType) => void;
 }
@@ -17,6 +17,9 @@ const FilterBar = ({ type, setType, sort, onSort }: FilterBarProps) => {
     <div className="sticky top-[48px] z-40 bg-basic-white">
       <div className="flex w-full justify-between px-16 pb-16 pt-12">
         <div className="flex gap-8">
+          <Chip onClick={() => setType('ALL')} isSelected={type === 'ALL'}>
+            전체
+          </Chip>
           <Chip
             onClick={() => setType('CONCERT')}
             isSelected={type === 'CONCERT'}
@@ -28,6 +31,12 @@ const FilterBar = ({ type, setType, sort, onSort }: FilterBarProps) => {
             isSelected={type === 'FESTIVAL'}
           >
             페스티벌
+          </Chip>
+          <Chip
+            onClick={() => setType('SPORTS')}
+            isSelected={type === 'SPORTS'}
+          >
+            스포츠
           </Chip>
         </div>
         <FilterButton sort={sort} onSort={onSort} />

--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -14,8 +14,10 @@ import FilterBar from './components/FilterBar';
 import { EventSortType } from '@/app/event/event.const';
 import { dateString } from '@/utils/dateString.util';
 
+export type EventTypeWithAll = EventType | 'ALL';
+
 const Page = () => {
-  const [type, setType] = useState<EventType>('CONCERT');
+  const [type, setType] = useState<EventTypeWithAll>('ALL');
   const [sort, setSort] = useState<EventSortType>('DATE_ASC');
   const {
     data: events,
@@ -31,10 +33,12 @@ const Page = () => {
     [events],
   );
 
-  const filteredEventsByType = useMemo(
-    () => filteredEventsByStatus?.filter((event) => event.eventType === type),
-    [filteredEventsByStatus, type],
-  );
+  const filteredEventsByType = useMemo(() => {
+    if (type === 'ALL') {
+      return filteredEventsByStatus;
+    }
+    return filteredEventsByStatus?.filter((event) => event.eventType === type);
+  }, [filteredEventsByStatus, type]);
 
   const sortedEvents = useMemo(
     () =>

--- a/src/components/chips/Chip.tsx
+++ b/src/components/chips/Chip.tsx
@@ -11,7 +11,7 @@ const Chip = ({ children, onClick, isSelected }: Props) => {
     <button
       type="button"
       onClick={onClick}
-      className={`inline-flex items-center justify-center whitespace-nowrap break-keep rounded-[28px] px-12 py-8 text-14 font-600 leading-[160%] ${
+      className={`inline-flex h-32 items-center justify-center whitespace-nowrap break-keep rounded-[28px] px-12 text-14 font-600 leading-[160%] ${
         isSelected
           ? 'bg-brand-primary-400 text-basic-white'
           : 'bg-basic-grey-100 text-basic-grey-700'

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -10,4 +10,5 @@ export const TRIP_STATUS_TO_STRING: Record<TripType, string> = {
 export const EVENT_TYPE_TO_STRING: Record<EventType, string> = {
   CONCERT: '콘서트',
   FESTIVAL: '페스티벌',
+  SPORTS: '스포츠',
 } as const;

--- a/src/types/event.type.ts
+++ b/src/types/event.type.ts
@@ -3,7 +3,7 @@ import { ArtistsViewEntitySchema } from './artist.type';
 
 //  ----- ENUM -----
 
-export const EventTypeEnum = z.enum(['CONCERT', 'FESTIVAL']);
+export const EventTypeEnum = z.enum(['CONCERT', 'FESTIVAL', 'SPORTS']);
 export type EventType = z.infer<typeof EventTypeEnum>;
 
 export const EventStatusEnum = z.enum([


### PR DESCRIPTION
## 개요

행사 목록 및 캐러셀에 전체 행사 필터 버튼을 추가하고, 스포트 행사 타입을 반영 했습니다.

## 변경사항

<img width="610" alt="스크린샷 2025-07-10 오전 11 48 43" src="https://github.com/user-attachments/assets/c8b25006-dc99-40f7-ae28-a371b24d442c" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).