### PR TITLE
fix: 용인 지역 주소 검색 제한 상수 수정

### DIFF
--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -62,23 +62,31 @@ const Page = () => {
         ) : (
           sortedEvents &&
           sortedEvents.length > 0 &&
-          sortedEvents?.map((event) => (
-            <div className="w-full px-[16px] py-[6px]" key={event.eventId}>
-              <Card
-                key={event.eventId}
-                image={event.eventImageUrl}
-                variant="SMALL"
-                title={event.eventName}
-                date={dateString([event.startDate, event.endDate], {
-                  showWeekday: false,
-                })}
-                location={event.eventLocationName}
-                price={`${event.minRoutePrice?.toLocaleString()}원 ~`}
-                isSaleStarted={event.hasOpenRoute}
-                href={`/event/${event.eventId}`}
-              />
-            </div>
-          ))
+          sortedEvents?.map((event) => {
+            const formattedDate = dateString(
+              event.startDate === event.endDate
+                ? event.startDate
+                : [event.startDate, event.endDate],
+              {
+                showWeekday: false,
+              },
+            );
+            return (
+              <div className="w-full px-[16px] py-[6px]" key={event.eventId}>
+                <Card
+                  key={event.eventId}
+                  image={event.eventImageUrl}
+                  variant="SMALL"
+                  title={event.eventName}
+                  date={formattedDate}
+                  location={event.eventLocationName}
+                  price={`${event.minRoutePrice?.toLocaleString()}원 ~`}
+                  isSaleStarted={event.hasOpenRoute}
+                  href={`/event/${event.eventId}`}
+                />
+              </div>
+            );
+          })
         )}
         {!isLoading && (
           <>

--- a/src/constants/handyPartyArea.const.ts
+++ b/src/constants/handyPartyArea.const.ts
@@ -64,7 +64,11 @@ export const HANDY_PARTY_AREA_TO_ADDRESS: Record<
   안산: { sido: '경기', gungu: ['안산시'] },
   하남: { sido: '경기', gungu: ['하남시'] },
   남양주: { sido: '경기', gungu: ['남양주시'] },
-  용인: { sido: '경기', gungu: ['수지구', '기흥구'] },
+  용인: {
+    sido: '경기',
+    gungu: ['용인시'],
+    dong: ['수지구', '기흥구'],
+  },
   시흥: { sido: '경기', gungu: ['시흥시'] },
   파주: {
     sido: '경기',


### PR DESCRIPTION
## 개요

핸디팟에서 용인 지역 검색 시 의도대로 지역이 제한되어 검색되지 않던 버그를 해결했습니다.
그 외에 행사 목록 페이지에서 행사 날짜가 하루일 때에도 ~ 표시를 통해 보이던 이슈를 해결했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).