### PR TITLE
fix: 카카오 스크립트 미로딩 에러 수정

### DIFF
--- a/src/app/event/[eventId]/components/handy-party/HandyPartyModal.tsx
+++ b/src/app/event/[eventId]/components/handy-party/HandyPartyModal.tsx
@@ -4,9 +4,7 @@ import useFunnel from '@/hooks/useFunnel';
 import TripTypeStep from './components/steps/TripTypeStep';
 import AddressStep from './components/steps/AddressStep';
 import ReservationInfoStep from './components/steps/ReservationInfoStep';
-import { useState } from 'react';
 import { ShuttleRoutesViewEntity, TripType } from '@/types/shuttleRoute.type';
-import KakaoMapScript from '@/components/kakao-map/KakaoMapScript';
 import { FormProvider, useForm } from 'react-hook-form';
 import { HandyPartyRouteArea } from '@/constants/handyPartyArea.const';
 
@@ -45,8 +43,6 @@ const HandyPartyModal = ({
     HANDY_PARTY_MODAL_STEPS,
   );
 
-  const [isKakaoMapScriptLoaded, setIsKakaoMapScriptLoaded] = useState(false);
-
   const methods = useForm<HandyPartyModalFormValues>({
     defaultValues: {
       tripType: undefined,
@@ -69,20 +65,11 @@ const HandyPartyModal = ({
     <ModalPortal>
       <FormProvider {...methods}>
         <div className="fixed bottom-0 left-0 right-0 top-0 z-[9999] mx-auto flex h-[100dvh] max-w-500 flex-col bg-basic-white">
-          <KakaoMapScript
-            onReady={() => setIsKakaoMapScriptLoaded(true)}
-            libraries={['services']}
-          />
           <Funnel>
             <Step name="방향 선택">
               <TripTypeStep
                 onBack={closeModal}
-                onNext={() => {
-                  if (!isKakaoMapScriptLoaded) {
-                    return;
-                  }
-                  handleNextStep();
-                }}
+                onNext={handleNextStep}
                 handyPartyRoutes={handyPartyRoutes}
               />
             </Step>

--- a/src/app/event/[eventId]/components/shuttle-route-detail-view/components/Hub.tsx
+++ b/src/app/event/[eventId]/components/shuttle-route-detail-view/components/Hub.tsx
@@ -16,7 +16,6 @@ interface Props {
   index: number;
   addOpenedHubIndex: (index: number) => void;
   removeOpenedHubIndex: (index: number) => void;
-  isKakaoMapScriptLoaded: boolean;
   hideTime?: boolean;
 }
 
@@ -28,7 +27,6 @@ const Hub = ({
   index,
   addOpenedHubIndex,
   removeOpenedHubIndex,
-  isKakaoMapScriptLoaded,
   hideTime = false,
 }: Props) => {
   const formattedTime = dateString(hub.arrivalTime, {
@@ -103,7 +101,6 @@ const Hub = ({
             placeName={hub.name}
             latitude={hub.latitude}
             longitude={hub.longitude}
-            isKakaoMapScriptLoaded={isKakaoMapScriptLoaded}
           />
         </div>
       </div>

--- a/src/app/event/[eventId]/components/shuttle-route-detail-view/components/Hubs.tsx
+++ b/src/app/event/[eventId]/components/shuttle-route-detail-view/components/Hubs.tsx
@@ -4,8 +4,6 @@ import {
 } from '@/types/shuttleRoute.type';
 import { getHubType } from '../shuttleRouteDetailView.util';
 import Hub from './Hub';
-import { useState } from 'react';
-import KakaoMapScript from '@/components/kakao-map/KakaoMapScript';
 
 interface Props {
   hubs: ShuttleRouteHubsInShuttleRoutesViewEntity[];
@@ -24,10 +22,8 @@ const Hubs = ({
   removeOpenedHubIndex,
   isHandyParty,
 }: Props) => {
-  const [isKakaoMapScriptLoaded, setIsKakaoMapScriptLoaded] = useState(false);
   return (
     <>
-      <KakaoMapScript onReady={() => setIsKakaoMapScriptLoaded(true)} />
       {hubs.map((hub, index) => {
         const type = getHubType({
           index,
@@ -47,7 +43,6 @@ const Hubs = ({
             index={index}
             addOpenedHubIndex={addOpenedHubIndex}
             removeOpenedHubIndex={removeOpenedHubIndex}
-            isKakaoMapScriptLoaded={isKakaoMapScriptLoaded}
             hideTime={hideTime}
           />
         );

--- a/src/app/event/[eventId]/components/shuttle-route-detail-view/components/KakaoMap.tsx
+++ b/src/app/event/[eventId]/components/shuttle-route-detail-view/components/KakaoMap.tsx
@@ -6,15 +6,9 @@ interface Props {
   placeName: string;
   latitude: number;
   longitude: number;
-  isKakaoMapScriptLoaded: boolean;
 }
 
-const KakaoMap = ({
-  placeName,
-  latitude,
-  longitude,
-  isKakaoMapScriptLoaded,
-}: Props) => {
+const KakaoMap = ({ placeName, latitude, longitude }: Props) => {
   const mapRef = useRef<HTMLDivElement>(null);
   const isInitialized = useRef(false);
 
@@ -44,12 +38,12 @@ const KakaoMap = ({
   };
 
   useEffect(() => {
-    if (!mapRef.current || isInitialized.current || !isKakaoMapScriptLoaded) {
+    if (!mapRef.current || isInitialized.current) {
       return;
     }
     isInitialized.current = true;
     window.kakao.maps.load(initializeMap);
-  }, [mapRef, isKakaoMapScriptLoaded]);
+  }, [mapRef]);
 
   return (
     <div

--- a/src/app/event/[eventId]/page.tsx
+++ b/src/app/event/[eventId]/page.tsx
@@ -6,6 +6,7 @@ import { getEvent } from '@/services/event.service';
 import EventContent from './components/EventContent';
 import EventOverview from './components/EventOverview';
 import EventModal from './components/EventModal';
+import KakaoMapScript from '@/components/kakao-map/KakaoMapScript';
 
 interface Props {
   params: {
@@ -31,6 +32,7 @@ const Page = async ({ params }: Props) => {
         <EventModal eventId={params.eventId} />
         <div className="h-100 bg-basic-grey-50" />
       </main>
+      <KakaoMapScript libraries={['services']} />
     </>
   );
 };

--- a/src/app/mypage/shuttle/components/reservations/reservation-card/hooks/useEventText.ts
+++ b/src/app/mypage/shuttle/components/reservations/reservation-card/hooks/useEventText.ts
@@ -67,7 +67,7 @@ const useEventText = ({ reservation, event, dailyEvent }: Props) => {
       } else {
         if (
           toDestinationStartHub?.regionHubId ===
-          fromDestinationStartHub?.regionHubId
+          fromDestinationEndHub?.regionHubId
         ) {
           hubText = `${toDestinationStartHub?.name} ↔ ${toDestinationEndHub?.name}`;
         } else {


### PR DESCRIPTION
## 개요

핸디팟 예약 과정 중에서 카카오 스크립트가 미로딩 시에 에러가 발생하는 문제를 해결했습니다.
기존에 카카오 스크립트를 특정 상황에서만 로딩하면 부분을 페이지 진입시에 전역적으로 로딩하도록 변경했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).