### PR TITLE
feat: 예약 취소 사유 모달

### DIFF
--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/Content.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/Content.tsx
@@ -104,7 +104,7 @@ const Content = ({ reservation, payment, shuttleBus }: Props) => {
         </WrapperWithDivider>
         <WrapperWithDivider>
           <ReservationPersonInfoSection
-            nickname={reservation.userNickname}
+            name={reservation.userName}
             phoneNumber={reservation.userPhoneNumber}
           />
         </WrapperWithDivider>

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/Content.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/Content.tsx
@@ -127,7 +127,11 @@ const Content = ({ reservation, payment, shuttleBus }: Props) => {
           />
         </WrapperWithDivider>
         <GuidelineSection />
-        <RefundSection isCanceled={isCanceled} reservation={reservation} />
+        <RefundSection
+          isCanceled={isCanceled}
+          isEnded={isEnded}
+          reservation={reservation}
+        />
       </ul>
     </main>
   );

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/ReservationPersonInfoSection.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/ReservationPersonInfoSection.tsx
@@ -1,18 +1,18 @@
 import { formatPhoneNumber } from '@/utils/common.util';
 
 interface Props {
-  nickname: string;
+  name: string;
   phoneNumber: string;
 }
 
-const ReservationPersonInfoSection = ({ nickname, phoneNumber }: Props) => {
+const ReservationPersonInfoSection = ({ name, phoneNumber }: Props) => {
   const formattedPhoneNumber = formatPhoneNumber(phoneNumber);
   return (
     <section className="px-16">
       <h3 className="pb-16 text-16 font-600">예약자 정보</h3>
       <div className="grid grid-cols-[72px_1fr] gap-x-16 gap-y-8 text-14 font-600">
         <h5>예약자명</h5>
-        <p>{nickname}</p>
+        <p>{name}</p>
         <h5>연락처</h5>
         <p>{formattedPhoneNumber}</p>
       </div>

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/RefundSection.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/RefundSection.tsx
@@ -5,10 +5,11 @@ import { ReservationsViewEntity } from '@/types/reservation.type';
 
 interface Props {
   isCanceled: boolean;
+  isEnded: boolean;
   reservation: ReservationsViewEntity;
 }
 
-const RefundSection = ({ isCanceled, reservation }: Props) => {
+const RefundSection = ({ isCanceled, isEnded, reservation }: Props) => {
   const {
     bottomSheetRef: cancelBottomSheetRef,
     contentRef: cancelBottomSheetContentRef,
@@ -16,7 +17,7 @@ const RefundSection = ({ isCanceled, reservation }: Props) => {
     closeBottomSheet: closeCancelBottomSheet,
   } = useBottomSheet();
 
-  if (isCanceled) {
+  if (isCanceled || isEnded) {
     return <div className="h-64 w-full" />;
   }
 

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/components/CancelBottomSheet.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/components/CancelBottomSheet.tsx
@@ -12,8 +12,27 @@ import { usePutCancelReservation } from '@/services/reservation.service';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 import { CustomError } from '@/services/custom-error';
+import useFunnel from '@/hooks/useFunnel';
+import {
+  CANCEL_REASON_DETAIL_OPTIONS,
+  CANCEL_REASON_OPTIONS,
+  REFUND_STEPS,
+} from '../const/refund.const';
+import useHistory from '../hooks/useHistory';
+import useBottomSheetText from '../hooks/useBottomSheetText';
+import { useForm } from 'react-hook-form';
+import { usePostFeedback } from '@/services/core.service';
+import { createFeedbackContent } from '../utils/createFeedbackContent.util';
+import RadioInputGroup from './RadioInputGroup';
 
 const USER_CANCELLATION_FEE_REASON = '자동 승인 환불 요청';
+
+export interface CancelReasonForm {
+  cancelReason: string;
+  cancelReasonDescription: string;
+  cancelReasonDetail: string;
+  cancelReasonDetailDescription: string;
+}
 
 interface Props extends BottomSheetRefs {
   reservation: ReservationsViewEntity | null;
@@ -28,11 +47,45 @@ const CancelBottomSheet = ({
 }: Props) => {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    getValues,
+    trigger,
+    control,
+    formState: { errors },
+  } = useForm<CancelReasonForm>({});
 
-  const refundFee = useMemo(
-    () => calculateRefundFee(reservation),
-    [reservation],
+  const initialStep = REFUND_STEPS[0];
+  const { Funnel, Step, setStep, stepName } = useFunnel(
+    REFUND_STEPS,
+    initialStep,
   );
+
+  const { title: bottomSheetTitle, description: bottomSheetDescription } =
+    useBottomSheetText({ stepName });
+
+  const { isHistoryAvailable, handleBack, setHistoryAndStep } = useHistory({
+    stepName,
+    setStep,
+  });
+
+  const { refundFee, paymentAmount, refundAmount } = useMemo(() => {
+    const refundFee = calculateRefundFee(reservation);
+    const paymentAmount = reservation?.paymentAmount ?? null;
+    const refundAmount =
+      paymentAmount !== null && refundFee !== null
+        ? paymentAmount - refundFee
+        : null;
+
+    return {
+      refundFee,
+      paymentAmount,
+      refundAmount,
+    };
+  }, [reservation]);
+
   const isRefundable = useMemo(() => {
     return getIsRefundable(reservation);
   }, [reservation]);
@@ -41,11 +94,26 @@ const CancelBottomSheet = ({
     usePostRefund();
   const { mutateAsync: putCancelReservation, isPending: isCancelPending } =
     usePutCancelReservation();
+  const { mutateAsync: postFeedback, isPending: isFeedbackPending } =
+    usePostFeedback();
 
-  const handleSubmit = async () => {
+  const onSubmit = async () => {
     if (!reservation || !reservation.paymentId) {
       return;
     }
+
+    const content = createFeedbackContent(reservation, getValues);
+
+    try {
+      await postFeedback({
+        subject: '셔틀 예약 취소 사유',
+        content,
+      });
+    } catch (e) {
+      console.error(e);
+      toast.error('취소 사유를 제출하지 못했어요.');
+    }
+
     try {
       if (isRefundable) {
         await postRefund({
@@ -77,36 +145,152 @@ const CancelBottomSheet = ({
     }
   };
 
+  const handleClickCancelReasonNextButton = async () => {
+    const cancelReason = getValues('cancelReason');
+    if (!cancelReason) return;
+
+    if (cancelReason === CANCEL_REASON_OPTIONS.OTHER) {
+      const isValid = await trigger(['cancelReasonDescription']);
+      if (!isValid) return;
+    }
+
+    if (cancelReason === CANCEL_REASON_OPTIONS.OTHER_SHUTTLE) {
+      setHistoryAndStep('조금만 더 자세히 알려주시겠어요?');
+    } else {
+      setHistoryAndStep('정말 취소하시겠어요?');
+    }
+  };
+
+  const handleClickCancelReasonDetailNextButton = async () => {
+    const cancelReasonDetail = getValues('cancelReasonDetail');
+    if (!cancelReasonDetail) return;
+
+    if (cancelReasonDetail === CANCEL_REASON_DETAIL_OPTIONS.OTHER) {
+      const isValid = await trigger(['cancelReasonDetailDescription']);
+
+      if (!isValid) return;
+    }
+
+    setHistoryAndStep('정말 취소하시겠어요?');
+  };
+
   return (
     <BottomSheet
       ref={bottomSheetRef}
-      title="취소하시겠어요?"
-      description="예약을 취소하시면 서비스 정책에 따라 취소 수수료가 발생하며 사용하신 결제 수단으로 수수료를 제외한 금액이 자동 환불됩니다."
+      title={bottomSheetTitle}
+      description={bottomSheetDescription}
+      showBackButton={isHistoryAvailable}
+      onBack={handleBack}
     >
       <div ref={contentRef} className="max-h-[55dvh] overflow-y-auto">
-        {refundFee !== null && (
-          <article className="mb-16 flex w-full flex-col items-center justify-center gap-8 rounded-8 bg-basic-grey-50 px-16 py-12">
-            <h5 className="text-18 font-600 text-basic-grey-700">
-              취소 수수료
-            </h5>
-            <p className="text-14 font-600 text-basic-red-400">
-              {refundFee.toLocaleString()}원
-            </p>
-          </article>
-        )}
-      </div>
-      <div className="flex flex-col gap-8">
-        <Button
-          type="button"
-          onClick={handleSubmit}
-          variant="p-destructive"
-          disabled={isRefundPending || isCancelPending}
-        >
-          취소하기
-        </Button>
-        <Button type="button" onClick={closeBottomSheet} variant="text">
-          닫기
-        </Button>
+        <Funnel>
+          <Step name="취소하시겠어요?">
+            {refundFee !== null && (
+              <article className="mb-16 flex w-full flex-col items-center justify-center gap-8 rounded-8 bg-basic-grey-50 px-16 py-12">
+                <h5 className="text-18 font-600 text-basic-grey-700">
+                  취소 수수료
+                </h5>
+                <p className="text-14 font-600 text-basic-red-400">
+                  {refundFee.toLocaleString()}원
+                </p>
+              </article>
+            )}
+            <div className="flex flex-col gap-8">
+              <Button
+                type="button"
+                onClick={() => setHistoryAndStep('취소 사유를 알려주세요')}
+                variant="s-destructive"
+              >
+                취소 진행하기
+              </Button>
+              <Button type="button" onClick={closeBottomSheet} variant="text">
+                예약 유지하기
+              </Button>
+            </div>
+          </Step>
+
+          <Step name="취소 사유를 알려주세요">
+            <RadioInputGroup
+              options={CANCEL_REASON_OPTIONS}
+              name="cancelReason"
+              otherOptionName="cancelReasonDescription"
+              register={register}
+              setValue={setValue}
+              control={control}
+              errors={errors}
+            />
+            <div className="flex flex-col gap-8">
+              <Button
+                type="button"
+                onClick={handleClickCancelReasonNextButton}
+                variant="s-destructive"
+              >
+                다음
+              </Button>
+              <Button type="button" onClick={closeBottomSheet} variant="text">
+                예약 유지하기
+              </Button>
+            </div>
+          </Step>
+
+          <Step name="조금만 더 자세히 알려주시겠어요?">
+            <RadioInputGroup
+              options={CANCEL_REASON_DETAIL_OPTIONS}
+              name="cancelReasonDetail"
+              otherOptionName="cancelReasonDetailDescription"
+              register={register}
+              setValue={setValue}
+              control={control}
+              errors={errors}
+            />
+            <div className="flex flex-col gap-8">
+              <Button
+                type="button"
+                onClick={handleClickCancelReasonDetailNextButton}
+                variant="s-destructive"
+              >
+                다음
+              </Button>
+              <Button type="button" onClick={closeBottomSheet} variant="text">
+                예약 유지하기
+              </Button>
+            </div>
+          </Step>
+
+          <Step name="정말 취소하시겠어요?">
+            {refundFee !== null &&
+              refundAmount !== null &&
+              paymentAmount !== null && (
+                <article className="mb-16 flex w-full flex-col items-center justify-center gap-8 rounded-8 bg-basic-grey-50 px-16 py-12">
+                  <h5 className="text-16 font-600 leading-[160%] text-basic-grey-700">
+                    환불 예정 금액
+                  </h5>
+                  <p className="text-16 font-600 leading-[160%] text-basic-black">
+                    {refundAmount.toLocaleString()}원
+                  </p>
+                  <p className="text-12 font-500 leading-[160%] text-basic-grey-600">
+                    ({paymentAmount.toLocaleString()}원 -{' '}
+                    {refundFee.toLocaleString()}원)
+                  </p>
+                </article>
+              )}
+            <div className="flex flex-col gap-8">
+              <Button
+                type="button"
+                onClick={handleSubmit(onSubmit)}
+                variant="p-destructive"
+                disabled={
+                  isRefundPending || isCancelPending || isFeedbackPending
+                }
+              >
+                취소하기
+              </Button>
+              <Button type="button" onClick={closeBottomSheet} variant="text">
+                예약 유지하기
+              </Button>
+            </div>
+          </Step>
+        </Funnel>
       </div>
     </BottomSheet>
   );

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/components/RadioInputGroup.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/components/RadioInputGroup.tsx
@@ -1,0 +1,93 @@
+import {
+  Control,
+  FieldErrors,
+  UseFormRegister,
+  UseFormSetValue,
+} from 'react-hook-form';
+
+import { useWatch } from 'react-hook-form';
+import { CANCEL_REASON_OPTIONS } from '../const/refund.const';
+import { CancelReasonForm } from './CancelBottomSheet';
+
+interface RadioInputGroupProps {
+  options: Record<string, string>;
+  name: keyof CancelReasonForm;
+  otherOptionName?: keyof CancelReasonForm;
+  register: UseFormRegister<CancelReasonForm>;
+  setValue: UseFormSetValue<CancelReasonForm>;
+  errors?: FieldErrors<CancelReasonForm>;
+  otherOptionPlaceholder?: string;
+  control?: Control<CancelReasonForm>;
+}
+
+const RadioInputGroup = ({
+  options,
+  name,
+  otherOptionName,
+  register,
+  setValue,
+  errors,
+  otherOptionPlaceholder = '직접 입력해주세요. (50자 내외)',
+  control,
+}: RadioInputGroupProps) => {
+  const selectedItem = useWatch({ control, name });
+
+  const handleRadioChange = (value: string) => {
+    setValue(name, value);
+    if (value !== CANCEL_REASON_OPTIONS.OTHER && otherOptionName) {
+      setValue(otherOptionName, '');
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-16">
+      {Object.entries(options).map(([key, item]) => (
+        <div
+          key={key}
+          className="group"
+          onClick={() => handleRadioChange(item)}
+        >
+          <div className="flex items-center gap-[6px]">
+            <input
+              type="radio"
+              {...register(name)}
+              value={item}
+              checked={selectedItem === item}
+              className="h-[18px] w-[18px] accent-basic-black"
+            />
+            <label className="text-16 font-600 leading-[160%]">{item}</label>
+          </div>
+          {item === CANCEL_REASON_OPTIONS.OTHER && otherOptionName && (
+            <div>
+              <input
+                type="text"
+                {...register(otherOptionName, {
+                  required:
+                    selectedItem === item ? '내용을 입력해주세요.' : false,
+                  pattern: {
+                    value: /^.{1,50}$/,
+                    message: '최대 50자까지 입력할 수 있어요.',
+                  },
+                })}
+                className={`w-full border-b border-basic-grey-200 p-12 text-16 font-500 leading-[160%] text-basic-grey-700 focus:outline-none ${
+                  selectedItem !== item
+                    ? 'disabled:bg-basic-white disabled:opacity-50'
+                    : ''
+                } ${errors?.[otherOptionName] ? 'border-basic-red-400' : ''}`}
+                placeholder={otherOptionPlaceholder}
+                disabled={selectedItem !== item}
+              />
+              {errors?.[otherOptionName] && (
+                <p className="mt-4 text-12 font-500 text-basic-red-400">
+                  {errors[otherOptionName].message}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RadioInputGroup;

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/const/refund.const.ts
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/const/refund.const.ts
@@ -1,0 +1,51 @@
+import { ReactNode } from 'react';
+
+export const CANCEL_REASON_OPTIONS = {
+  SCHEDULE_CHANGE: '일정이 변경되었어요.',
+  PRICE_BURDEN: '가격이 부담돼요.',
+  LOCATION_TIME_MISMATCH: '정류장/시간이 맞지 않아요.',
+  OTHER_SHUTTLE: '다른 셔틀을 이용하려고요.',
+  SIMPLE_CHANGE: '단순 변심',
+  OTHER: '기타',
+} as const;
+
+export const CANCEL_REASON_DETAIL_OPTIONS = {
+  BETTER_TIME: '원하는 시간대에 운행해요.',
+  CLOSER_LOCATION: '출발지/도착지가 더 가까워요.',
+  LOWER_PRICE: '가격이 더 저렵해요.',
+  OTHER: '기타',
+} as const;
+
+export const REFUND_STEPS = [
+  '취소하시겠어요?',
+  '취소 사유를 알려주세요',
+  '조금만 더 자세히 알려주시겠어요?',
+  '정말 취소하시겠어요?',
+] as const;
+
+export const REFUND_STEPS_TO_TEXT: Record<
+  (typeof REFUND_STEPS)[number],
+  {
+    title: ReactNode | ((input: string) => ReactNode);
+    description?: ReactNode | ((input: string) => ReactNode);
+  }
+> = {
+  '취소하시겠어요?': {
+    title: '취소하시겠어요?',
+    description:
+      '지금 예약을 취소하시면 서비스 정책에 따라 아래와 같은 취소 수수료가 발생해요.',
+  },
+  '취소 사유를 알려주세요': {
+    title: '취소 사유를 알려주세요',
+    description: '사유를 알려주시면 서비스 개선에 도움이 됩니다.',
+  },
+  '조금만 더 자세히 알려주시겠어요?': {
+    title: '조금만 더 자세히 알려주시겠어요?',
+    description: '더 나은 핸디버스를 만들도록 노력하겠습니다.',
+  },
+  '정말 취소하시겠어요?': {
+    title: '정말 취소하시겠어요?',
+    description:
+      '취소하기를 누르면 되돌아갈 수 없어요. 취소 후에는 사용하신 결제 수단으로 수수료를 제외한 금액이 자동 환불됩니다.',
+  },
+} as const;

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/hooks/useBottomSheetText.ts
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/hooks/useBottomSheetText.ts
@@ -1,0 +1,21 @@
+import { ReactNode, useMemo } from 'react';
+import { REFUND_STEPS, REFUND_STEPS_TO_TEXT } from '../const/refund.const';
+
+interface UseBottomSheetTextProps {
+  stepName: (typeof REFUND_STEPS)[number];
+}
+
+const useBottomSheetText = ({ stepName }: UseBottomSheetTextProps) => {
+  const text = useMemo(() => getBottomSheetText(stepName), [stepName]);
+  return text;
+};
+
+const getBottomSheetText = (stepName: (typeof REFUND_STEPS)[number]) => {
+  const text = REFUND_STEPS_TO_TEXT[stepName];
+  return {
+    title: text.title as ReactNode,
+    description: text.description as ReactNode,
+  };
+};
+
+export default useBottomSheetText;

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/hooks/useHistory.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/hooks/useHistory.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { REFUND_STEPS } from '../const/refund.const';
+
+interface Props {
+  stepName: (typeof REFUND_STEPS)[number];
+  setStep: (step: (typeof REFUND_STEPS)[number]) => void;
+}
+
+const useHistory = ({ stepName, setStep }: Props) => {
+  const [history, setHistory] = useState<(typeof REFUND_STEPS)[number][]>([]);
+  const isHistoryAvailable = history.length > 0;
+
+  const setHistoryAndStep = (nextStep: (typeof REFUND_STEPS)[number]) => {
+    const currStep = stepName;
+    setHistory((prev) => [currStep, ...prev]);
+    setStep(nextStep);
+  };
+
+  const handleBack = () => {
+    const step = history[0];
+    if (!step) {
+      return;
+    }
+    setStep(step);
+    setHistory((prev) => prev.slice(1));
+  };
+
+  const resetHistory = () => {
+    setHistory([]);
+  };
+
+  return {
+    isHistoryAvailable,
+    setHistoryAndStep,
+    handleBack,
+    resetHistory,
+  };
+};
+
+export default useHistory;

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/utils/createFeedbackContent.util.ts
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/utils/createFeedbackContent.util.ts
@@ -1,0 +1,41 @@
+import { ReservationsViewEntity } from '@/types/reservation.type';
+import { UseFormGetValues } from 'react-hook-form';
+import {
+  CANCEL_REASON_DETAIL_OPTIONS,
+  CANCEL_REASON_OPTIONS,
+} from '../const/refund.const';
+
+interface CancelReasonForm {
+  cancelReason: string;
+  cancelReasonDescription: string;
+  cancelReasonDetail: string;
+  cancelReasonDetailDescription: string;
+}
+
+export const createFeedbackContent = (
+  reservation: ReservationsViewEntity,
+  getValues: UseFormGetValues<CancelReasonForm>,
+) => {
+  const cancelReason = getValues('cancelReason');
+  const cancelReasonDescription = getValues('cancelReasonDescription');
+  const cancelReasonDetail = getValues('cancelReasonDetail');
+  const cancelReasonDetailDescription = getValues(
+    'cancelReasonDetailDescription',
+  );
+
+  const baseContent = `ReservationId: ${reservation.reservationId}, 취소 사유: ${cancelReason}`;
+  const baseDescription =
+    cancelReason === CANCEL_REASON_OPTIONS.OTHER
+      ? `, 기타 의견: ${cancelReasonDescription}`
+      : '';
+
+  let detailContent = '';
+  if (cancelReason === CANCEL_REASON_OPTIONS.OTHER_SHUTTLE) {
+    detailContent = `, 취소 사유 상세: ${cancelReasonDetail}`;
+    if (cancelReasonDetail === CANCEL_REASON_DETAIL_OPTIONS.OTHER) {
+      detailContent += `, 상세 기타 의견: ${cancelReasonDetailDescription}`;
+    }
+  }
+
+  return baseContent + baseDescription + detailContent;
+};

--- a/src/types/reservation.type.ts
+++ b/src/types/reservation.type.ts
@@ -34,6 +34,7 @@ export const ReservationsViewEntitySchema = z
   .object({
     reservationId: z.string(),
     userId: z.string(),
+    userName: z.string(),
     userNickname: z.string(),
     userPhoneNumber: z.string(),
     userProfileImage: z.string().nullable(),


### PR DESCRIPTION
## 개요
예약 취소 사유 모달을 반영했습니다.

## 변경사항
- 예약 내역에 실명 반영 안된 곳 실명 반영
- 셔틀 종료시 예약 취소 불가 처리
- 예약 취소 사유 모달

https://github.com/user-attachments/assets/ee6c59ba-82c5-412f-8e1b-5c0c4ca0a605

| 작성한 예약 취소 사유들은 어드민 - 피드백에서 보실 수 있습니다 |
|--|
|<img width="533" height="183" alt="Screenshot 2025-08-01 at 2 21 05 PM" src="https://github.com/user-attachments/assets/5587ad83-c7ed-42ea-9714-1aa0aa1cced3" />|

## 헤맨부분 (라디오 버튼 커스텀 스타일)
선택시 선택 색깔을 바꾸려면 accentColor 스타일을 사용하면 됩니다. 그러나 테두리 색 border 를 수정하려면 appearence:none 을 적용해야하는데요, 이러면 accentColor 스타일을 적용할 수 없습니다. 즉, 선택시 가운데에 색상이 차오르는 효과를 직접 구현해야하는데요, 이를 시도해보았지만 2-3시간안에 처리할 수 없어서 보류하였습니다. 현재는 border 색깔 회색을 포기하고 accentColor 를 회색으로 반영하는 방식으로 간단하게 처리되어있습니다. 

보람님께서는 전혀 티 안난다고 문제없다고 하셨는데 그래도 궁금해져서 혹시 appearence:none 을 적용하고 선택시 가운데 차오르는 커스텀 스타일을 어떻게 만들 수 있는지 아시면 댓글 달아주시면 감사하겠습니다 🙇🏻‍♂️

| figma | 적용된 디자인|
|--------|--------|
|<img width="586" height="674" alt="Screenshot 2025-08-01 at 2 24 28 PM" src="https://github.com/user-attachments/assets/8db78aab-4357-457a-8c47-fc5410df8ba8" />|<img width="342" height="268" alt="Screenshot 2025-08-01 at 2 30 06 PM" src="https://github.com/user-attachments/assets/83ef2751-c1cc-4bdd-9ea4-fa43e493f334" />|


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).