### PR TITLE
fix: 예약 취소 모달 기타 input 사용성 개선

### DIFF
--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/components/RadioInputGroup.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/refund-section/components/RadioInputGroup.tsx
@@ -34,19 +34,12 @@ const RadioInputGroup = ({
 
   const handleRadioChange = (value: string) => {
     setValue(name, value);
-    if (value !== CANCEL_REASON_OPTIONS.OTHER && otherOptionName) {
-      setValue(otherOptionName, '');
-    }
   };
 
   return (
     <div className="flex flex-col gap-16">
       {Object.entries(options).map(([key, item]) => (
-        <div
-          key={key}
-          className="group"
-          onClick={() => handleRadioChange(item)}
-        >
+        <div key={key} onClick={() => handleRadioChange(item)}>
           <div className="flex items-center gap-[6px]">
             <input
               type="radio"
@@ -70,12 +63,9 @@ const RadioInputGroup = ({
                   },
                 })}
                 className={`w-full border-b border-basic-grey-200 p-12 text-16 font-500 leading-[160%] text-basic-grey-700 focus:outline-none ${
-                  selectedItem !== item
-                    ? 'disabled:bg-basic-white disabled:opacity-50'
-                    : ''
+                  selectedItem !== item ? 'opacity-50' : ''
                 } ${errors?.[otherOptionName] ? 'border-basic-red-400' : ''}`}
                 placeholder={otherOptionPlaceholder}
-                disabled={selectedItem !== item}
               />
               {errors?.[otherOptionName] && (
                 <p className="mt-4 text-12 font-500 text-basic-red-400">


### PR DESCRIPTION
## 개요
기타 input 의 사용성을 개선했습니다.

갑자기 해결방법이 뚝딱 떠올라서 10분안에 개발 및 작성완료하였습니다

## 변경사항
- 초기요청 : 기타 라디오 버튼을 클릭하지 않더라도 input을 클릭하면 라디오 버튼이 클릭되고 input 이 disabled->albed로 사용하고 싶음
- 문제점 : raido 버튼과 input을 가진 부모 태그에 onClick 이벤트를 두었으나, input을 클릭해도 라디오 버튼이 선택되지 않음. 추측하건데 disabled 속성을 주면, input의 클릭 이벤트 자체가 발생하지 않아서, 부모태그의 onClick 이벤트 자체가 발동하지 않음.
- 해결방법 : 기타 input의 disabled를 사용하지 않음, 대신 기타를 선택하지 않았을때, css style로 투명도를 줘서 비활성화 된 것처럼 보이게 만듦.

https://github.com/user-attachments/assets/5c0affdc-4645-4dce-bca2-82cd32622d1b


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).