### PR TITLE
feat: 예약완료페이지에 공지방 링크 반영, 핸디팟은 기본 페이지처리

### DIFF
--- a/src/app/event/[eventId]/dailyevent/[dailyEventId]/route/[shuttleRouteId]/payment/request/[reservationId]/page.tsx
+++ b/src/app/event/[eventId]/dailyevent/[dailyEventId]/route/[shuttleRouteId]/payment/request/[reservationId]/page.tsx
@@ -3,9 +3,10 @@
 import Button from '@/components/buttons/button/Button';
 import usePreventScroll from '@/hooks/usePreventScroll';
 import Link from 'next/link';
-import { useState } from 'react';
 import SuccessBusIcon from '../icons/bus-success.svg';
-import FeedbackScreen from '@/components/feedback/FeedbackScreen';
+import { useGetUserReservation } from '@/services/reservation.service';
+import Loading from '@/components/loading/Loading';
+import { HANDY_PARTY_PREFIX } from '@/constants/common';
 
 interface Props {
   params: {
@@ -16,21 +17,21 @@ interface Props {
 
 const PaymentsCompleted = ({ params }: Props) => {
   usePreventScroll();
-
-  const [showFeedbackScreen, setShowFeedbackScreen] = useState(false);
-  if (showFeedbackScreen) {
-    return (
-      <FeedbackScreen
-        subject="예약 - 성공"
-        closeFeedbackScreen={() => setShowFeedbackScreen(false)}
-      />
-    );
-  }
-
   const { reservationId } = params;
+  const { data, isLoading, isError } = useGetUserReservation(reservationId);
 
-  return (
-    <>
+  if (isLoading) return <Loading />;
+  if (isError) throw new Error('예약 정보를 불러오는데 실패했습니다.');
+
+  const isHandyParty =
+    data?.reservation.shuttleRoute.name.includes(HANDY_PARTY_PREFIX);
+  const dailyEventId = data?.reservation.shuttleRoute.dailyEventId;
+  const noticeRoomUrl = data?.reservation.shuttleRoute.event.dailyEvents.find(
+    (dailyEvent) => dailyEvent.dailyEventId === dailyEventId,
+  )?.metadata?.openChatUrl;
+
+  if (isHandyParty) {
+    return (
       <main className="relative grow">
         <section className="absolute left-1/2 top-180 flex -translate-x-1/2 flex-col items-center whitespace-nowrap break-keep">
           <h1 className="pb-4 text-22 font-700">셔틀 예약이 완료되었어요</h1>
@@ -43,19 +44,38 @@ const PaymentsCompleted = ({ params }: Props) => {
           <Link href={`/event/${params.eventId}`}>
             <Button>완료</Button>
           </Link>
+        </div>
+      </main>
+    );
+  }
+  return (
+    <>
+      <main className="relative grow">
+        <section className="absolute left-1/2 top-180 flex -translate-x-1/2 flex-col items-center whitespace-nowrap break-keep">
+          <h1 className="pb-4 text-22 font-700">셔틀 예약이 완료되었어요</h1>
+          <p className="pb-24 text-center text-16 font-500 text-basic-grey-600">
+            탑승권은 마이페이지에서 확인할 수 있습니다.
+            <br />
+            모든 현장 안내는 공지방에서 전달드리니,
+            <br />
+            탑승 전 꼭 입장해 주세요.
+          </p>
+          <SuccessBusIcon />
+        </section>
+        <div className="fixed bottom-0 left-0 right-0 mx-auto flex max-w-500 flex-col gap-8 p-16">
           <Button
-            variant="secondary"
+            variant="primary"
             size="large"
             onClick={() => {
-              window.open(
-                `/mypage/boarding-pass?reservationId=${reservationId}`,
-                '_blank',
-                'noopener,noreferrer',
-              );
+              window.open(noticeRoomUrl, '_blank', 'noopener,noreferrer');
             }}
+            disabled={!noticeRoomUrl}
           >
-            탑승권 확인하기
+            공지방 입장하기
           </Button>
+          <Link href={`/event/${params.eventId}`}>
+            <Button variant="secondary">완료</Button>
+          </Link>
         </div>
       </main>
     </>


### PR DESCRIPTION
## 개요
- 예약완료페이지 업데이트

- 유저들은 예약완료페이지에 로딩화면이 있을 수 있습니다. (셔틀버스, 핸디팟 구분, 오픈챗방 링크 데이터 필요)

|셔틀버스 예약완료|핸디팟 예약완료|
|-|-|
|<img width="370" height="669" alt="Screenshot 2025-08-08 at 12 49 15 PM" src="https://github.com/user-attachments/assets/e3fd0c94-1291-40db-9c57-53a10ce98f58" />|<img width="358" height="667" alt="Screenshot 2025-08-08 at 12 49 24 PM" src="https://github.com/user-attachments/assets/e031b1c2-0713-4be7-917c-c0454de48aed" />|

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).