### PR TITLE
refactor: eventWithRoutes 뷰 테이블을 event 뷰 테이블로 대체

### DIFF
--- a/src/app/(home)/@event/components/PinnedEventCard.tsx
+++ b/src/app/(home)/@event/components/PinnedEventCard.tsx
@@ -14,7 +14,7 @@ interface Props {
   events: EventsViewEntity[] | null | undefined;
 }
 
-const RecommendedEventCard = ({ events }: Props) => {
+const PinnedEventCard = ({ events }: Props) => {
   const [type, setType] = useState<EventTypeWithAll>('ALL');
 
   // 각 이벤트 타입별로 이벤트가 있는지 확인
@@ -62,4 +62,4 @@ const RecommendedEventCard = ({ events }: Props) => {
   );
 };
 
-export default RecommendedEventCard;
+export default PinnedEventCard;

--- a/src/app/(home)/@event/components/RecommendedEventCard.tsx
+++ b/src/app/(home)/@event/components/RecommendedEventCard.tsx
@@ -2,11 +2,7 @@
 
 import Chip from '@/components/chips/Chip';
 import { useMemo, useState } from 'react';
-import {
-  EventType,
-  EventTypeEnum,
-  EventWithRoutesViewEntity,
-} from '@/types/event.type';
+import { EventType, EventTypeEnum, EventsViewEntity } from '@/types/event.type';
 import { EVENT_TYPE_TO_STRING } from '@/constants/status';
 import RecommendedEventSwiperView from './RecommendedEventSwiperView';
 import CardSection from './CardSection';
@@ -15,7 +11,7 @@ import Empty from '@/app/event/components/Empty';
 type EventTypeWithAll = EventType | 'ALL';
 
 interface Props {
-  events: EventWithRoutesViewEntity[] | null | undefined;
+  events: EventsViewEntity[] | null | undefined;
 }
 
 const RecommendedEventCard = ({ events }: Props) => {

--- a/src/app/(home)/@event/components/RecommendedEventSwiperView.tsx
+++ b/src/app/(home)/@event/components/RecommendedEventSwiperView.tsx
@@ -7,11 +7,11 @@ import 'swiper/css';
 import Card from '@/components/card/Card';
 import ViewAllButton from '@/app/(home)/@event/components/ViewAllButton';
 import Link from 'next/link';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 import { dateString } from '@/utils/dateString.util';
 
 interface Props {
-  events: EventWithRoutesViewEntity[];
+  events: EventsViewEntity[];
 }
 
 const RecommendedEventSwiperView = ({ events }: Props) => {
@@ -52,8 +52,8 @@ const RecommendedEventSwiperView = ({ events }: Props) => {
                     title={v.eventName}
                     date={formattedDate}
                     location={v.eventLocationName}
-                    price={`${v.minRoutePrice?.toLocaleString()}원 ~`}
-                    isSaleStarted={v.hasOpenRoute}
+                    price={`${v.eventMinRoutePrice?.toLocaleString()}원 ~`}
+                    isSaleStarted={v.eventHasOpenRoute}
                     order={idx + 1}
                     href={`/event/${v.eventId}`}
                   />

--- a/src/app/(home)/@event/components/TrendEventCard.tsx
+++ b/src/app/(home)/@event/components/TrendEventCard.tsx
@@ -2,10 +2,10 @@
 
 import CardSection from './CardSection';
 import TrendEventsSwiperView from './TrendEventsSwiperView';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 
 interface Props {
-  events: EventWithRoutesViewEntity[] | null | undefined;
+  events: EventsViewEntity[] | null | undefined;
 }
 
 const TrendEventCard = ({ events }: Props) => {

--- a/src/app/(home)/@event/components/TrendEventsSwiperView.tsx
+++ b/src/app/(home)/@event/components/TrendEventsSwiperView.tsx
@@ -5,12 +5,12 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import type { SwiperRef } from 'swiper/react';
 import 'swiper/css';
 import Card from '@/components/card/Card';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 
 const MIN_CARD_COUNT = 5;
 
 interface Props {
-  events: EventWithRoutesViewEntity[];
+  events: EventsViewEntity[];
 }
 
 const TrendEventsSwiperView = ({ events }: Props) => {
@@ -46,8 +46,8 @@ const TrendEventsSwiperView = ({ events }: Props) => {
                     title={v.eventName}
                     date={v.startDate}
                     location={v.eventLocationName}
-                    price={`${v.minRoutePrice?.toLocaleString()}원 ~`}
-                    isSaleStarted={v.hasOpenRoute}
+                    price={`${v.eventMinRoutePrice?.toLocaleString()}원 ~`}
+                    isSaleStarted={v.eventHasOpenRoute}
                     order={(idx % cardCount) + 1}
                     href={`/event/${v.eventId}`}
                   />

--- a/src/app/(home)/@event/page.tsx
+++ b/src/app/(home)/@event/page.tsx
@@ -1,16 +1,12 @@
 import TrendEventCard from './components/TrendEventCard';
-import RecommendedEventCard from './components/RecommendedEventCard';
-import { getEvents } from '@/services/event.service';
+import PinnedEventCard from './components/PinnedEventCard';
+import { getEvents, getTopRecommendedEvents } from '@/services/event.service';
 import { EventsViewEntity } from '@/types/event.type';
 
 const Page = async () => {
-  const popularEvents = await getEvents({
-    status: 'OPEN,CLOSED',
-    orderBy: 'eventRecommendationScore',
-    additionalOrderOptions: 'DESC',
-  });
+  const recommendedEvents = await getTopRecommendedEvents(5);
 
-  const recommendedEvents = await getEvents({
+  const pinnedEvents = await getEvents({
     status: 'OPEN,CLOSED',
     eventIsPinned: true,
   });
@@ -20,14 +16,14 @@ const Page = async () => {
       event.eventStatus === 'CLOSED' && !event.eventHasOpenRoute ? false : true,
     ) ?? [];
 
-  const filteredPopularEvents = filteredEventsByStatus(popularEvents);
   const filteredRecommendedEvents = filteredEventsByStatus(recommendedEvents);
+  const filteredPinnedEvents = filteredEventsByStatus(pinnedEvents);
 
   return (
     <>
-      <TrendEventCard events={filteredPopularEvents} />
+      <TrendEventCard events={filteredRecommendedEvents} />
       <div className="my-16 h-8 w-full bg-basic-grey-50" />
-      <RecommendedEventCard events={filteredRecommendedEvents} />
+      <PinnedEventCard events={filteredPinnedEvents} />
       <div className="my-16 h-8 w-full bg-basic-grey-50" />
     </>
   );

--- a/src/app/(home)/@event/page.tsx
+++ b/src/app/(home)/@event/page.tsx
@@ -1,7 +1,7 @@
 import TrendEventCard from './components/TrendEventCard';
 import RecommendedEventCard from './components/RecommendedEventCard';
 import { getEvents } from '@/services/event.service';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 
 const Page = async () => {
   const popularEvents = await getEvents({
@@ -15,9 +15,9 @@ const Page = async () => {
     eventIsPinned: true,
   });
 
-  const filteredEventsByStatus = (events: EventWithRoutesViewEntity[]) =>
+  const filteredEventsByStatus = (events: EventsViewEntity[]) =>
     events?.filter((event) =>
-      event.eventStatus === 'CLOSED' && !event.hasOpenRoute ? false : true,
+      event.eventStatus === 'CLOSED' && !event.eventHasOpenRoute ? false : true,
     ) ?? [];
 
   const filteredPopularEvents = filteredEventsByStatus(popularEvents);

--- a/src/app/event/[eventId]/components/EventContent.tsx
+++ b/src/app/event/[eventId]/components/EventContent.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 import EventForm from './event-form/EventForm';
 import { Provider as JotaiProvider } from 'jotai';
 import ShuttleRouteDetailView from './shuttle-route-detail-view/ShuttleRouteDetailView';
 
 interface Props {
-  event: EventWithRoutesViewEntity;
+  event: EventsViewEntity;
 }
 
 const EventContent = ({ event }: Props) => {

--- a/src/app/event/[eventId]/components/EventInfo.tsx
+++ b/src/app/event/[eventId]/components/EventInfo.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import Badge from '@/components/badge/Badge';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 import { dateString } from '@/utils/dateString.util';
 import { getPhaseAndEnabledStatus } from '@/utils/event.util';
 
 export const HANDY_PARTY_AREA_GUIDE_ID = 'handy-party-area-guide';
 
 interface Props {
-  event: EventWithRoutesViewEntity;
+  event: EventsViewEntity;
 }
 
 const EventInfo = ({ event }: Props) => {
@@ -43,7 +43,7 @@ const EventInfo = ({ event }: Props) => {
         {enabledStatus === 'enabled' &&
           (phase === 'reservation' ? (
             <h5 className="text-20 font-600">
-              {event.minRoutePrice?.toLocaleString()}원~
+              {event.eventMinRoutePrice?.toLocaleString()}원~
             </h5>
           ) : (
             <div className="flex items-center gap-4">

--- a/src/app/event/[eventId]/components/event-form/EventForm.tsx
+++ b/src/app/event/[eventId]/components/event-form/EventForm.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import BottomSheet from '@/components/bottom-sheet/BottomSheet';
 import useFunnel from '@/hooks/useFunnel';
 import { EVENT_FORM_DEFAULT_VALUES, EVENT_STEPS } from '../../form.const';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 import {
   getPhaseAndEnabledStatus,
   EventEnabledStatus,
@@ -44,7 +44,7 @@ import { HANDY_PARTY_AREA_GUIDE_ID } from '../EventInfo';
 import ShareBottomSheet from './components/ShareBottomSheet';
 
 interface Props {
-  event: EventWithRoutesViewEntity;
+  event: EventsViewEntity;
 }
 
 const EventForm = ({ event }: Props) => {
@@ -57,7 +57,7 @@ const EventForm = ({ event }: Props) => {
       status: 'OPEN',
     },
     {
-      enabled: event.hasOpenRoute,
+      enabled: event.eventHasOpenRoute,
     },
   );
   const shuttleRoutes = useMemo(
@@ -65,7 +65,7 @@ const EventForm = ({ event }: Props) => {
     [shuttleRoutesPages],
   );
   const isShuttleRoutesLoading =
-    event.hasOpenRoute && shuttleRoutes.length === 0;
+    event.eventHasOpenRoute && shuttleRoutes.length === 0;
 
   if (isShuttleRoutesLoading) {
     return (
@@ -110,7 +110,7 @@ const EventForm = ({ event }: Props) => {
 export default EventForm;
 
 interface ContentProps {
-  event: EventWithRoutesViewEntity;
+  event: EventsViewEntity;
   shuttleRoutes: ShuttleRoutesViewEntity[];
   phase: EventPhase;
   enabledStatus: EventEnabledStatus;

--- a/src/app/event/[eventId]/components/event-form/hooks/useEventInitialization.tsx
+++ b/src/app/event/[eventId]/components/event-form/hooks/useEventInitialization.tsx
@@ -8,10 +8,10 @@ import { getUserDemands } from '@/services/demand.service';
 import { userAlertRequestsAtom } from '../../../store/userAlertRequestsAtom';
 import { getUserAlertRequests } from '@/services/alertRequest.service';
 import { ShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 
 interface Props {
-  event: EventWithRoutesViewEntity;
+  event: EventsViewEntity;
   shuttleRoutes: ShuttleRoutesViewEntity[];
 }
 

--- a/src/app/event/[eventId]/dailyevent/[dailyEventId]/route/[shuttleRouteId]/payment/components/Content.tsx
+++ b/src/app/event/[eventId]/dailyevent/[dailyEventId]/route/[shuttleRouteId]/payment/components/Content.tsx
@@ -1,5 +1,5 @@
 import { IssuedCouponsViewEntity } from '@/types/coupon.type';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 import { ShuttleRoutesViewEntity, TripType } from '@/types/shuttleRoute.type';
 import { useEffect, useState } from 'react';
 import { UsersViewEntity } from '@/types/user.type';
@@ -27,7 +27,7 @@ interface ContentProps {
   toDestinationHubId: string | null;
   fromDestinationHubId: string | null;
   passengerCount: number;
-  event: EventWithRoutesViewEntity;
+  event: EventsViewEntity;
   shuttleRoute: ShuttleRoutesViewEntity;
   user: UsersViewEntity;
   coupons: IssuedCouponsViewEntity[];

--- a/src/app/event/[eventId]/dailyevent/[dailyEventId]/route/[shuttleRouteId]/payment/components/sections/EventInfoSection.tsx
+++ b/src/app/event/[eventId]/dailyevent/[dailyEventId]/route/[shuttleRouteId]/payment/components/sections/EventInfoSection.tsx
@@ -1,17 +1,17 @@
 import { DEFAULT_EVENT_IMAGE } from '@/constants/common';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 import { dateString } from '@/utils/dateString.util';
 import Image from 'next/image';
 
 interface Props {
-  event: EventWithRoutesViewEntity;
+  event: EventsViewEntity;
 }
 
 const EventInfoSection = ({ event }: Props) => {
   const formattedDate = dateString([event.startDate, event.endDate], {
     showWeekday: false,
   });
-  const formattedMinPrice = event.minRoutePrice?.toLocaleString();
+  const formattedMinPrice = event.eventMinRoutePrice?.toLocaleString();
   return (
     <section className="px-16 pb-24 pt-12">
       <h1 className="mb-24 text-22 font-700 leading-[140%]">예약 내역</h1>

--- a/src/app/event/[eventId]/store/eventAtom.ts
+++ b/src/app/event/[eventId]/store/eventAtom.ts
@@ -1,4 +1,4 @@
 import { atom } from 'jotai';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 
-export const eventAtom = atom<EventWithRoutesViewEntity | null>(null);
+export const eventAtom = atom<EventsViewEntity | null>(null);

--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -28,7 +28,9 @@ const Page = () => {
   const filteredEventsByStatus = useMemo(
     () =>
       events?.filter((event) =>
-        event.eventStatus === 'CLOSED' && !event.hasOpenRoute ? false : true,
+        event.eventStatus === 'CLOSED' && !event.eventHasOpenRoute
+          ? false
+          : true,
       ),
     [events],
   );
@@ -80,8 +82,8 @@ const Page = () => {
                   title={event.eventName}
                   date={formattedDate}
                   location={event.eventLocationName}
-                  price={`${event.minRoutePrice?.toLocaleString()}원 ~`}
-                  isSaleStarted={event.hasOpenRoute}
+                  price={`${event.eventMinRoutePrice?.toLocaleString()}원 ~`}
+                  isSaleStarted={event.eventHasOpenRoute}
                   href={`/event/${event.eventId}`}
                 />
               </div>

--- a/src/app/event/toSorted.util.ts
+++ b/src/app/event/toSorted.util.ts
@@ -1,12 +1,9 @@
 import { EventSortType } from '@/app/event/event.const';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 import dayjs from 'dayjs';
 
-export const toSorted = (
-  events: EventWithRoutesViewEntity[],
-  sort: EventSortType,
-) => {
-  let newData: EventWithRoutesViewEntity[];
+export const toSorted = (events: EventsViewEntity[], sort: EventSortType) => {
+  let newData: EventsViewEntity[];
   switch (sort) {
     case 'NAME_ASC':
       newData = events.toSorted((a, b) =>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -65,7 +65,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  const events = await getEvents({ status: 'OPEN' });
+  const events = await getEvents({ status: 'OPEN,CLOSED' });
   const eventsArray = events.map((event) => ({
     url: `${baseUrl}/event/${event.eventId}`,
     lastModified: new Date(event.updatedAt),

--- a/src/services/event.service.ts
+++ b/src/services/event.service.ts
@@ -1,8 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import {
-  EventStatus,
-  EventWithRoutesViewEntitySchema,
-} from '@/types/event.type';
+import { EventStatus, EventsViewEntitySchema } from '@/types/event.type';
 import { instance } from './config';
 import { Combinations, withPagination } from '@/types/common.type';
 import { toSearchParams } from '@/utils/searchParams.util';
@@ -15,10 +12,10 @@ export const getEvents = async (params?: {
 }) => {
   const searchParams = toSearchParams(params);
   const res = await instance.get(
-    `/v3/shuttle-operation/events?${searchParams.toString()}`,
+    `/v2/shuttle-operation/events?${searchParams.toString()}`,
     {
       shape: withPagination({
-        events: EventWithRoutesViewEntitySchema.array(),
+        events: EventsViewEntitySchema.array(),
       }),
     },
   );
@@ -37,9 +34,9 @@ export const useGetEvents = (params?: {
   });
 
 export const getEvent = async (eventId: string) => {
-  const res = await instance.get(`/v3/shuttle-operation/events/${eventId}`, {
+  const res = await instance.get(`/v2/shuttle-operation/events/${eventId}`, {
     shape: {
-      event: EventWithRoutesViewEntitySchema,
+      event: EventsViewEntitySchema,
     },
   });
   return res.event;

--- a/src/services/event.service.ts
+++ b/src/services/event.service.ts
@@ -51,3 +51,23 @@ export const useGetEvent = (
     queryFn: () => getEvent(eventId),
     enabled,
   });
+
+// OPEN,CLOSED 인 행사 중 추천 점수가 높은 순으로 행사 조회
+export const getTopRecommendedEvents = async (limit?: number) => {
+  const searchParams = toSearchParams({ limit });
+  const res = await instance.get(
+    `/v2/shuttle-operation/events/top/recommended?${searchParams.toString()}`,
+    {
+      shape: {
+        events: EventsViewEntitySchema.array(),
+      },
+    },
+  );
+  return res.events;
+};
+
+export const useGetTopRecommendedEvents = (limit?: number) =>
+  useQuery({
+    queryKey: ['event', 'top', 'recommended', limit],
+    queryFn: () => getTopRecommendedEvents(limit),
+  });

--- a/src/types/event.type.ts
+++ b/src/types/event.type.ts
@@ -43,6 +43,9 @@ export const EventsViewEntitySchema = z
     eventLocationLatitude: z.number(),
     eventLocationLongitude: z.number(),
     eventIsPinned: z.number(), // TOOD: 백엔드 버그. boolean으로 변경 필요
+    eventMinRoutePrice: z.number(),
+    eventHasOpenRoute: z.boolean(),
+    eventRecommendationScore: z.number(),
     eventArtists: ArtistsViewEntitySchema.array().nullable(),
     dailyEvents: DailyEventsInEventsViewEntitySchema.array(),
     startDate: z.string(),
@@ -53,13 +56,3 @@ export const EventsViewEntitySchema = z
   })
   .strict();
 export type EventsViewEntity = z.infer<typeof EventsViewEntitySchema>;
-
-export const EventWithRoutesViewEntitySchema = EventsViewEntitySchema.extend({
-  minRoutePrice: z.number().nullable(),
-  hasOpenRoute: z.boolean(),
-  eventIsPinned: z.boolean(),
-  eventRecommendationScore: z.number(),
-});
-export type EventWithRoutesViewEntity = z.infer<
-  typeof EventWithRoutesViewEntitySchema
->;

--- a/src/types/event.type.ts
+++ b/src/types/event.type.ts
@@ -42,7 +42,7 @@ export const EventsViewEntitySchema = z
     eventLocationAddress: z.string(),
     eventLocationLatitude: z.number(),
     eventLocationLongitude: z.number(),
-    eventIsPinned: z.number(), // TOOD: 백엔드 버그. boolean으로 변경 필요
+    eventIsPinned: z.boolean(),
     eventMinRoutePrice: z.number(),
     eventHasOpenRoute: z.boolean(),
     eventRecommendationScore: z.number(),

--- a/src/utils/event.util.ts
+++ b/src/utils/event.util.ts
@@ -1,7 +1,7 @@
 import { MAX_HANDY_DISCOUNT_AMOUNT } from '@/constants/common';
 import { CustomError } from '@/services/custom-error';
 import { IssuedCouponsViewEntity } from '@/types/coupon.type';
-import { EventWithRoutesViewEntity } from '@/types/event.type';
+import { EventsViewEntity } from '@/types/event.type';
 import { ShuttleRoutesViewEntity, TripType } from '@/types/shuttleRoute.type';
 import { compareToNow } from '@/utils/dateString.util';
 
@@ -9,7 +9,7 @@ export type EventPhase = 'demand' | 'reservation';
 export type EventEnabledStatus = 'enabled' | 'disabled';
 
 export const getPhaseAndEnabledStatus = (
-  event: EventWithRoutesViewEntity | null | undefined,
+  event: EventsViewEntity | null | undefined,
 ): {
   phase: EventPhase;
   enabledStatus: EventEnabledStatus;
@@ -18,8 +18,8 @@ export const getPhaseAndEnabledStatus = (
     return { phase: 'demand', enabledStatus: 'disabled' };
   }
   const isDemandOngoing = event.eventStatus === 'OPEN';
-  const isReservationOpen = event.minRoutePrice !== null;
-  const isReservationOngoing = event.hasOpenRoute;
+  const isReservationOpen = event.eventMinRoutePrice !== null;
+  const isReservationOngoing = event.eventHasOpenRoute;
 
   switch (true) {
     case isDemandOngoing && !isReservationOpen:


### PR DESCRIPTION
## 개요

쿼리 성능 이슈로 인해 eventWithRoutes를 event로 대체하였습니다. 또한 기존에 홈에서 추천 점수 기반으로 order by로 보여주던 부분을 효울적인 api로 대체했습니다..


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).