### PR TITLE
fix: 쿠폰 등록 실패 메세지

### DIFF
--- a/src/app/mypage/coupons/components/RegisterCoupon.tsx
+++ b/src/app/mypage/coupons/components/RegisterCoupon.tsx
@@ -29,7 +29,7 @@ const RegisterCoupon = () => {
       } else if (error.statusCode === 409) {
         toast.error('이미 등록된 쿠폰이에요.');
       } else if (error.statusCode === 400) {
-        toast.error('쿠폰이 만료되었어요.');
+        toast.error(error.message);
       } else {
         toast.error('쿠폰을 등록하지 못했어요.');
       }

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -77,10 +77,15 @@ class Instance {
       }
 
       return silentParse(schema, data, { useToast: getNotifiedUsingToast });
-    } catch {
+    } catch (e) {
       // response가 없는 경우
-      if (res.status >= 400) {
+      if (res.status === 204) {
         throw new CustomError(res.status, 'No Content');
+      } else if (res.status >= 400) {
+        throw new CustomError(
+          res.status,
+          e instanceof Error ? e.message : '알 수 없는 오류',
+        );
       }
       return silentParse(
         schema,

--- a/src/services/custom-error.ts
+++ b/src/services/custom-error.ts
@@ -3,7 +3,7 @@ export class CustomError extends Error {
     public statusCode: number,
     message: string,
   ) {
-    super(statusCode + ' ' + message);
+    super(message);
     this.name = 'CustomError';
   }
 }


### PR DESCRIPTION
## 개요
쿠폰 등록 실패시 적절한 실패 이유를 보여줍니다.

## 본문
**(배경)** 현재 쿠폰 발급 실패시 error status 400 인 경우 쿠폰이 만료되었다는 메시지만 고정적으로 보여주고 있습니다. error.message 를 사용해서 이를 세분화하려고합니다.

400 에러 케이스들을 정리해보면 다음과 같습니다.
(API 문서에는 에러 케이스들이 자세하게 기록되어있지 않아서 백엔드 레포에서 v1/billing/coupons 에 해당하는 400 에러 메세지 케이스들을 정리했습니다.)
- 휴대폰 번호가 없습니다.
- 쿠폰이 유효하지 않습니다, 
- 쿠폰 발급 조건을 만족하지 않습니다. [구체적인 조건들]
- 쿠폰 발급 한도를 초과했습니다
- 쿠폰 처리 조건을 만족하지 않습니다
- 최대 사용 횟수는 현재 사용 횟수보다 작을 수 없습니다
- 할인율은 1~100% 사이여야 합니다
- 최대 할인 금액은 0보다 커야 합니다
- 할인 금액은 0보다 커야 합니다 
- 여러개의 에러메세지 (다중 쿠폰 발급시)

**(발견한 문제상황)** config.ts 72줄 `!data.ok` 의 조건을 만족하면 에러를 쓰로우하게 되는데요, 이 경우에 82줄 if 문을 만나게 됩니다. `statusCode >= 400` 인 경우 `CustomError(res.status, 'No Content')`를 쓰로우하게되는데요. 이때 error message가 존재해도 No Content가 주입됩니다. 이 때문에 특정 페이지에서 error.message를 사용하려고해도 400 No Content 라는 메세지만 나타나게 됩니다.

**(제안하는 해결방안)** `if (res.status === 204)` 로 No Content 응답을 위해 분기처리합니다. No Content 응답은 Response body가 비어있기 때문에 72줄에서 에러가 발생하고 에러캐치문으로 넘어오게 되는데요. 여기서 추가분기처리하여 `CustomError(res.status, 'No Content')` 를 쓰로우 해주면 됩니다.

그와 함께 custom-error.ts에서 6줄 `super(statusCode + ' ' + message);` 코드를 `super(message)` 로 변경하려고 합니다. (프로젝트 내에서 error status code 를 가지고 조건을 분기하긴 하지만, error.message를 직접 사용하는 곳은 존재하지 않는 것으로 확인하였기에 변경해도 문제없을 것이라 예상합니다)

(한계점) `v1/billing/coupon` api의 에러메세지를 그대로 보여주는 것이라 저희 프로덕트의 일관된 메세지 톤앤매너와 조금 어긋나보입니다.

## 변경사항
| 이미 발급된 쿠폰 |
|-|
|<img width="352" height="479" alt="Screenshot 2025-08-13 at 4 55 34 PM" src="https://github.com/user-attachments/assets/96b611ff-e1e1-46e6-9af8-af6718cc3d43" /> |



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).