### PR TITLE
feat: 고객 인증정보에서 받은 전화번호를 통해 저장하도록 수정

### DIFF
--- a/src/app/auth/identity-verification/page.tsx
+++ b/src/app/auth/identity-verification/page.tsx
@@ -10,11 +10,11 @@ import { useEffect, useRef } from 'react';
 import { toast } from 'react-toastify';
 
 interface Props {
-  searchParams: { identityVerificationId: string; phoneNumber: string };
+  searchParams: { identityVerificationId: string };
 }
 
 const Page = ({ searchParams }: Props) => {
-  const { identityVerificationId, phoneNumber } = searchParams;
+  const { identityVerificationId } = searchParams;
   const router = useRouter();
   const isInitiated = useRef(false);
   usePreventRefresh();
@@ -24,7 +24,6 @@ const Page = ({ searchParams }: Props) => {
     try {
       await postIdentityVerification({
         identityVerificationId,
-        phoneNumber,
       });
       setOnboardingStatusComplete();
       router.replace('/');

--- a/src/app/onboarding/components/steps/PhoneNumberStep.tsx
+++ b/src/app/onboarding/components/steps/PhoneNumberStep.tsx
@@ -36,7 +36,7 @@ const PhoneNumberStep = () => {
       storeId,
       identityVerificationId: `identity-verification-${crypto.randomUUID()}`,
       channelKey: danalChannelKey,
-      redirectUrl: `${redirectUrl}?phoneNumber=${phoneNumber}`,
+      redirectUrl,
       popup: {
         center: true,
       },
@@ -54,7 +54,7 @@ const PhoneNumberStep = () => {
     }
 
     router.replace(
-      `${redirectUrl}?phoneNumber=${phoneNumber}&identityVerificationId=${response.identityVerificationId}`,
+      `${redirectUrl}?identityVerificationId=${response.identityVerificationId}`,
     );
   };
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -52,7 +52,6 @@ export const postUpdateToken = async () => {
 // CSR 환경에서만 사용 가능
 export const postIdentityVerification = async (body: {
   identityVerificationId: string;
-  phoneNumber: string;
 }) => {
   return await authInstance.post('/v1/auth/identity-verification', body, {
     skipCheckOnboarding: true,


### PR DESCRIPTION
## 개요

유저 입력 값이 아닌 실제 고객 인증 정보를 통해 전화번호가 저장되도록 수정했습니다.
여전히 임의의 값을 입력하고 PASS의 QR을 통해 인증하면 bypass 되는 문제는 있지만, 서버에는 임의의 값이 아닌 실제 전화번호가 저장되기에 문제가 없다고 판단하여 막아두지 않았습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).