### PR TITLE
feat: 모든 try catch문에 sentry capture exception 추가

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,15 +5,18 @@
 
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: 'https://aeab1122ce73c3cb87f58b8d6dd5c945@o4509749985869824.ingest.us.sentry.io/4509874464817152',
+// 프로덕션 환경에서만 Sentry 활성화
+if (process.env.NODE_ENV === 'production') {
+  Sentry.init({
+    dsn: 'https://aeab1122ce73c3cb87f58b8d6dd5c945@o4509749985869824.ingest.us.sentry.io/4509874464817152',
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+    tracesSampleRate: 1,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+    // Enable logs to be sent to Sentry
+    enableLogs: true,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
+  });
+}

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,15 +4,18 @@
 
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: 'https://aeab1122ce73c3cb87f58b8d6dd5c945@o4509749985869824.ingest.us.sentry.io/4509874464817152',
+// 프로덕션 환경에서만 Sentry 활성화
+if (process.env.NODE_ENV === 'production') {
+  Sentry.init({
+    dsn: 'https://aeab1122ce73c3cb87f58b8d6dd5c945@o4509749985869824.ingest.us.sentry.io/4509874464817152',
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+    tracesSampleRate: 1,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+    // Enable logs to be sent to Sentry
+    enableLogs: true,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
+  });
+}

--- a/src/app/(home)/@greeting/page.tsx
+++ b/src/app/(home)/@greeting/page.tsx
@@ -14,6 +14,8 @@ import Link from 'next/link';
 import { toast } from 'react-toastify';
 import { getIsLoggedIn } from '@/utils/handleToken.util';
 import CheckIcon from './icons/check.svg';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
 
 const BOTTOM_SHEET_TEXT_MARKETING_AGREEMENT = {
   title: '정말 중요한 내용만 알려드릴게요',
@@ -55,6 +57,21 @@ const Page = () => {
       removeEntryGreetingIncomplete();
       closeBottomSheet();
     } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'GreetingPage',
+          page: 'home',
+          feature: 'onboarding',
+          section: 'marketing-consent',
+          userType: getIsLoggedIn() ? 'loggedIn' : 'anonymous',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          isMarketingAgreed,
+          hasEntryGreetingIncomplete: getEntryGreetingIncomplete(),
+          timestamp: dayjs().toISOString(),
+        },
+      });
       toast.error('잠시 후 다시 시도해주세요.');
       console.error(error);
     }

--- a/src/app/auth/identity-verification/page.tsx
+++ b/src/app/auth/identity-verification/page.tsx
@@ -8,6 +8,8 @@ import { logout, setOnboardingStatusComplete } from '@/utils/handleToken.util';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { toast } from 'react-toastify';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
 
 interface Props {
   searchParams: { identityVerificationId: string };
@@ -28,6 +30,18 @@ const Page = ({ searchParams }: Props) => {
       setOnboardingStatusComplete();
       router.replace('/');
     } catch (e) {
+      Sentry.captureException(e, {
+        tags: {
+          component: 'IdentityVerification',
+          page: 'auth',
+          feature: 'identity-verification',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          identityVerificationId,
+          timestamp: dayjs().toISOString(),
+        },
+      });
       console.error(e);
       toast.error('회원가입에 실패했어요.');
       logout();

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 import { logout } from '@/utils/handleToken.util';
 import { useEffect } from 'react';
 import * as Sentry from '@sentry/nextjs';
+import { usePathname } from 'next/navigation';
+import dayjs from 'dayjs';
 
 export const Error = ({
   error,
@@ -12,10 +14,28 @@ export const Error = ({
   error: Error & { digest?: string };
   reset: () => void;
 }) => {
+  const pathname = usePathname();
+
   useEffect(() => {
-    Sentry.captureException(error);
+    Sentry.captureException(error, {
+      tags: {
+        component: 'ErrorBoundary',
+        page: 'global-error',
+        feature: 'error-handling',
+        errorType: 'unhandled-error',
+        environment: process.env.NODE_ENV || 'development',
+      },
+      extra: {
+        errorName: error.name,
+        errorMessage: error.message,
+        errorStack: error.stack,
+        errorDigest: error.digest,
+        pathname,
+        timestamp: dayjs().toISOString(),
+      },
+    });
     console.error(error);
-  }, [error]);
+  }, [error, pathname]);
 
   return (
     <div className="flex grow flex-col px-20 py-28">

--- a/src/app/event/[eventId]/components/handy-party/components/steps/MapStep.tsx
+++ b/src/app/event/[eventId]/components/handy-party/components/steps/MapStep.tsx
@@ -9,6 +9,8 @@ import { checkIsPossibleHandyPartyArea } from '@/utils/handyParty.util';
 import { toast } from 'react-toastify';
 import { HandyPartyRouteArea } from '@/constants/handyPartyArea.const';
 import { useReservationTrackingGlobal } from '@/hooks/analytics/useReservationTrackingGlobal';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
 
 const DEFAULT_MAP_CENTER = {
   x: 127.02761,
@@ -131,6 +133,18 @@ const MapStep = ({ onBack, onNext, possibleHandyPartyAreas }: Props) => {
 
       kakaoGeocoder.current = new kakao.maps.services.Geocoder();
     } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'HandyPartyMapStep',
+          page: 'event-detail',
+          feature: 'handy-party',
+          action: 'initialize-kakao-map',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          timestamp: dayjs().toISOString(),
+        },
+      });
       console.error(error);
     }
   }, [getValues, searchAddressAndSetResult]);

--- a/src/app/event/[eventId]/components/shuttle-route-detail-view/components/KakaoMap.tsx
+++ b/src/app/event/[eventId]/components/shuttle-route-detail-view/components/KakaoMap.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
 
 interface Props {
   placeName: string;
@@ -33,6 +35,21 @@ const KakaoMap = ({ placeName, latitude, longitude }: Props) => {
         marker.setMap(map);
       }
     } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'ShuttleRouteDetailKakaoMap',
+          page: 'event-detail',
+          feature: 'map',
+          action: 'initialize-kakao-map',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          placeName,
+          latitude,
+          longitude,
+          timestamp: dayjs().toISOString(),
+        },
+      });
       console.error(error);
     }
   };

--- a/src/app/event/[eventId]/components/steps/components/RequestSeatAlarmButton.tsx
+++ b/src/app/event/[eventId]/components/steps/components/RequestSeatAlarmButton.tsx
@@ -16,6 +16,8 @@ import {
   checkIsUserAlertRequestAvailable,
   userAlertRequestsAtom,
 } from '../../../store/userAlertRequestsAtom';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
 
 interface Props {
   toStep: () => void;
@@ -64,6 +66,25 @@ const RequestSeatAlarmButton = ({ toStep, hubWithInfo, className }: Props) => {
 
       toStep();
     } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'RequestSeatAlarmButton',
+          page: 'event-detail',
+          feature: 'seat-alarm',
+          action: 'request-seat-alarm',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          eventId: event?.eventId,
+          dailyEventId,
+          shuttleRouteId: route?.shuttleRouteId,
+          hubInfo: {
+            regionHubId: hubWithInfo.regionHubId,
+            name: hubWithInfo.name,
+          },
+          timestamp: dayjs().toISOString(),
+        },
+      });
       console.error(error);
       toast.error('잠시 후 다시 시도해주세요.');
     }

--- a/src/app/event/[eventId]/components/steps/extra-steps/ExtraRealNameInputStep.tsx
+++ b/src/app/event/[eventId]/components/steps/extra-steps/ExtraRealNameInputStep.tsx
@@ -13,6 +13,8 @@ import { useRouter } from 'next/navigation';
 import { usePutUser } from '@/services/user.service';
 import { toast } from 'react-toastify';
 import { useReservationTrackingGlobal } from '@/hooks/analytics/useReservationTrackingGlobal';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
 interface Props {
   closeBottomSheet: () => void;
 }
@@ -83,6 +85,24 @@ const ExtraRealNameInputStep = ({ closeBottomSheet }: Props) => {
       closeBottomSheet();
       router.push(url);
     } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'ExtraRealNameInputStep',
+          page: 'event-detail',
+          feature: 'reservation',
+          action: 'update-name-and-reserve',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          eventId: event?.eventId,
+          dailyEventId: dailyEvent.dailyEventId,
+          shuttleRouteId: route?.shuttleRouteId,
+          tripType,
+          passengerCount,
+          userName: name ? 'provided' : 'missing',
+          timestamp: dayjs().toISOString(),
+        },
+      });
       console.error(error);
       toast.error('이름 변경에 실패했습니다. 잠시 후 다시 시도해주세요.');
     }

--- a/src/app/mypage/alert-requests/components/AlertRequestCard.tsx
+++ b/src/app/mypage/alert-requests/components/AlertRequestCard.tsx
@@ -9,6 +9,8 @@ import { useRouter } from 'next/navigation';
 import { handleClickAndStopPropagation } from '@/utils/common.util';
 import { toast } from 'react-toastify';
 import { useDeleteAlertRequest } from '@/services/alertRequest.service';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
 
 interface Props {
   alertRequest: ShuttleRouteAlertRequestsViewEntity;
@@ -28,6 +30,22 @@ const AlertRequestCard = ({ alertRequest }: Props) => {
       });
       toast.success('알림 요청을 취소했어요.');
     } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'AlertRequestCard',
+          page: 'mypage',
+          feature: 'alert-request',
+          action: 'delete-alert-request',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          eventId: alertRequest.shuttleRoute.event.eventId,
+          dailyEventId: alertRequest.shuttleRoute.dailyEventId,
+          shuttleRouteId: alertRequest.shuttleRoute.shuttleRouteId,
+          shuttleRouteAlertRequestId: alertRequest.shuttleRouteAlertRequestId,
+          timestamp: dayjs().toISOString(),
+        },
+      });
       console.error(error);
       toast.error('잠시 후 다시 시도해주세요.');
     }

--- a/src/app/mypage/coupons/components/RegisterCoupon.tsx
+++ b/src/app/mypage/coupons/components/RegisterCoupon.tsx
@@ -7,6 +7,8 @@ import { CustomError } from '@/services/custom-error';
 import { useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
 
 const RegisterCoupon = () => {
   const { control, setValue, handleSubmit } = useForm<{ coupon: string }>();
@@ -22,6 +24,21 @@ const RegisterCoupon = () => {
       setValue('coupon', '');
     } catch (e) {
       const error = e as CustomError;
+      Sentry.captureException(error, {
+        tags: {
+          component: 'RegisterCoupon',
+          page: 'mypage',
+          feature: 'coupon',
+          action: 'register-coupon',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          errorStatusCode: error.statusCode,
+          errorMessage: error.message,
+          couponCode: data.coupon ? 'provided' : 'empty',
+          timestamp: dayjs().toISOString(),
+        },
+      });
       console.error(error);
 
       if (error.statusCode === 404) {

--- a/src/app/mypage/reviews/edit/[reviewId]/components/ReviewEditForm.tsx
+++ b/src/app/mypage/reviews/edit/[reviewId]/components/ReviewEditForm.tsx
@@ -14,6 +14,8 @@ import { CreateReviewRequest, ReviewsViewEntity } from '@/types/review.type';
 import { usePutReview } from '@/services/review.service';
 import { useRouter } from 'next/navigation';
 import { getImageUrl } from '@/services/core.service';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
 
 interface Props {
   review: ReviewsViewEntity;
@@ -114,7 +116,23 @@ const ReviewEditForm = ({ review }: Props) => {
           .filter((url) => url !== null && url !== undefined)
           .map((url) => ({ imageUrl: url })),
       });
-    } catch {
+    } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'ReviewEditForm',
+          page: 'mypage',
+          feature: 'review',
+          action: 'edit-review',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          reviewId: review.reviewId,
+          eventId: review.eventId,
+          reservationId: review.reservationId,
+          imageCount: displayImages.length,
+          timestamp: dayjs().toISOString(),
+        },
+      });
       toast.error('후기를 수정하지 못했어요. 잠시 후 다시 시도해주세요.');
     }
   };

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,12 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
+import { useNotFoundTracking } from '@/hooks/useNotFoundTracking';
 
 export const NotFound = () => {
+  useNotFoundTracking();
+
   return (
     <div className="flex grow flex-col px-20 py-28">
       <h2 className="pb-[10px] text-26 font-700 text-basic-grey-700">

--- a/src/components/feedback/FeedbackScreen.tsx
+++ b/src/components/feedback/FeedbackScreen.tsx
@@ -5,6 +5,8 @@ import TextArea from '@/components/inputs/text-area/TextArea';
 import { usePostFeedback } from '@/services/core.service';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
 
 // NOTE: 피드백의 subject은 프론트에서 관리. 추후 기능 추가 및 기획 변경에 따라 타입 추가.
 type FeedbackSubject =
@@ -36,6 +38,19 @@ const FeedbackScreen = ({
       toast.success('소중한 의견 감사합니다!');
       closeFeedbackScreen();
     } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'FeedbackScreen',
+          feature: 'feedback',
+          action: 'submit-feedback',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          subject,
+          textLength: data.text ? data.text.length : 0,
+          timestamp: dayjs().toISOString(),
+        },
+      });
       console.error(error);
       toast.error('잠시 후 다시 시도해주세요.');
     }

--- a/src/components/kakao-map/KakaoMap.tsx
+++ b/src/components/kakao-map/KakaoMap.tsx
@@ -5,6 +5,8 @@ import Script from 'next/script';
 import LogoIcon from 'public/icons/logo-small.svg';
 import KakaoMapIcon from 'public/icons/kakaomap-logo.svg';
 import ChevronRightIcon from 'public/icons/chevron-right.svg';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
 
 interface Props {
   placeName: string;
@@ -51,6 +53,23 @@ const KakaoMap = ({ placeName, latitude, longitude }: Props) => {
         geocoder.coord2Address(coord.getLng(), coord.getLat(), callback);
       }
     } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'KakaoMap',
+          feature: 'map',
+          errorType: 'map-initialization-error',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          placeName,
+          latitude,
+          longitude,
+          kakaoApiKey: process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY
+            ? 'configured'
+            : 'missing',
+          timestamp: dayjs().toISOString(),
+        },
+      });
       console.error('지도를 불러오는 중 오류가 발생했습니다. \n' + error);
     }
   };

--- a/src/hooks/analytics/useShareTracking.ts
+++ b/src/hooks/analytics/useShareTracking.ts
@@ -7,6 +7,7 @@ import {
 } from '@/utils/analytics/shareAnalytics.util';
 import dayjs from 'dayjs';
 import { useScrollDepth } from './useScrollDepth';
+import * as Sentry from '@sentry/nextjs';
 
 /**
  * useShareTracking
@@ -60,6 +61,19 @@ export const useShareTracking = ({ eventId, eventName }: Props) => {
         status: 'no_action' as const,
       };
     } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'ShareTracking',
+          feature: 'analytics',
+          errorType: 'user-action-info-error',
+          environment: process.env.NODE_ENV || 'development',
+        },
+        extra: {
+          eventId,
+          eventName,
+          timestamp: dayjs().toISOString(),
+        },
+      });
       console.error('Failed to get user action info:', error);
       return {
         status: 'no_action' as const,

--- a/src/hooks/useNotFoundTracking.ts
+++ b/src/hooks/useNotFoundTracking.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import * as Sentry from '@sentry/nextjs';
+import dayjs from 'dayjs';
+
+/**
+ * 404 페이지 방문을 Sentry에 추적하는 커스텀 훅
+ */
+export const useNotFoundTracking = () => {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // 404 에러를 Sentry에 기록
+    Sentry.captureMessage('Page Not Found', {
+      level: 'warning',
+      tags: {
+        component: 'NotFound',
+        page: 'not-found',
+        feature: 'navigation',
+        errorType: '404-error',
+        environment: process.env.NODE_ENV || 'development',
+      },
+      extra: {
+        pathname,
+        referrer: typeof window !== 'undefined' ? document.referrer : 'unknown',
+        timestamp: dayjs().toISOString(),
+      },
+    });
+  }, [pathname]);
+};
+
+export default useNotFoundTracking;

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -4,27 +4,30 @@
 
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: 'https://aeab1122ce73c3cb87f58b8d6dd5c945@o4509749985869824.ingest.us.sentry.io/4509874464817152',
+// 프로덕션 환경에서만 Sentry 활성화
+if (process.env.NODE_ENV === 'production') {
+  Sentry.init({
+    dsn: 'https://aeab1122ce73c3cb87f58b8d6dd5c945@o4509749985869824.ingest.us.sentry.io/4509874464817152',
 
-  // Add optional integrations for additional features
-  integrations: [Sentry.replayIntegration()],
+    // Add optional integrations for additional features
+    integrations: [Sentry.replayIntegration()],
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+    tracesSampleRate: 1,
+    // Enable logs to be sent to Sentry
+    enableLogs: true,
 
-  // Define how likely Replay events are sampled.
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
+    // Define how likely Replay events are sampled.
+    // This sets the sample rate to be 10%. You may want this to be 100% while
+    // in development and sample at a lower rate in production
+    replaysSessionSampleRate: 0.1,
 
-  // Define how likely Replay events are sampled when an error occurs.
-  replaysOnErrorSampleRate: 1.0,
+    // Define how likely Replay events are sampled when an error occurs.
+    replaysOnErrorSampleRate: 1.0,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
+  });
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
## 개요
모든 try catch문에 captureExeption 을 추가하였습니다.


## 변경사항
**Tag, Extra**
- tag와 extra 정보를 추가하였는데요, 
tag는 어느 위치에서 발생했는지 sentry 에서 필터링이 가능하고, 
extra는 필터링은 안되지만 발생한 에러와 직접 관련된 정보를 담고 있습니다. 
- extra 정보에 더 많은 데이터를 반영하면 좋지만, 추가적인 api 로직을 반영해야하기 때문에
api 콜 없이 담을 수 있는 정보까지만 반영하였습니다.
- 우선은 임의로 데이터를 반영해두었는데요, 이후 sentry 에러 트래킹에서 필요한 데이터들이 생긴다면
추가 반영해두겠습니다

**Production 환경에서만 init**
- develop, local 환경에서는 sentry가 init 되지 않습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).