### PR TITLE
fix: 명동합정 노선 옵챗 추가 및 reservation card 에도 반영

### DIFF
--- a/src/app/event/[eventId]/dailyevent/[dailyEventId]/route/[shuttleRouteId]/payment/request/[reservationId]/page.tsx
+++ b/src/app/event/[eventId]/dailyevent/[dailyEventId]/route/[shuttleRouteId]/payment/request/[reservationId]/page.tsx
@@ -13,7 +13,8 @@ import Loading from '@/components/loading/Loading';
 import { HANDY_PARTY_PREFIX } from '@/constants/common';
 import { useReservationTracking } from '@/hooks/analytics/useReservationTracking';
 import { ReservationsViewEntity } from '@/types/reservation.type';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
+import useTempSeventeen from '@/hooks/useTempSeventeen';
 
 interface Props {
   params: {
@@ -55,58 +56,8 @@ const PaymentsCompletedPage = ({
     reservation.shuttleRoute.name.includes(HANDY_PARTY_PREFIX);
   const dailyEventId = reservation.shuttleRoute.dailyEventId;
 
-  const isSeventeenEvent =
-    reservation.shuttleRoute.eventId === '603038379151464486';
-  const temporaryNoticeRoomUrl: string | null = useMemo(() => {
-    const SHUTTLE_ROUTE_ID_13_대구 = '613618546496246356';
-    const SHUTTLE_ROUTE_ID_13_부산 = '613620913623012086';
-    const SHUTTLE_ROUTE_ID_13_대전 = '611769613054644567';
-    const SHUTTLE_ROUTE_ID_13_천안아산 = '613615679391666718';
-    const SHUTTLE_ROUTE_ID_13_청주 = '611771163789496897';
-    const OPEN_CHAT_URL_13_대구 = 'https://open.kakao.com/o/gwew7bQh';
-    const OPEN_CHAT_URL_13_부산 = 'https://open.kakao.com/o/gp1J7bQh';
-    const OPEN_CHAT_URL_13_대전 = 'https://open.kakao.com/o/gaoW7bQh';
-    const OPEN_CHAT_URL_13_천안아산 = 'https://open.kakao.com/o/gOF77bQh';
-    const OPEN_CHAT_URL_13_청주 = 'https://open.kakao.com/o/grNn8bQh';
-    const SHUTTLE_ROUTE_ID_14_대구 = '613623549873099706';
-    const SHUTTLE_ROUTE_ID_14_부산 = '613622643945378707';
-    const SHUTTLE_ROUTE_ID_14_대전 = '611770340053357083';
-    const SHUTTLE_ROUTE_ID_14_천안아산 = '613624012286727144';
-    const SHUTTLE_ROUTE_ID_14_청주 = '611771616103240128';
-    const OPEN_CHAT_URL_14_대구 = 'https://open.kakao.com/o/gRTC8bQh';
-    const OPEN_CHAT_URL_14_부산 = 'https://open.kakao.com/o/gSJS8bQh';
-    const OPEN_CHAT_URL_14_대전 = 'https://open.kakao.com/o/gbVe9bQh';
-    const OPEN_CHAT_URL_14_천안아산 = 'https://open.kakao.com/o/gZau9bQh';
-    const OPEN_CHAT_URL_14_청주 = 'https://open.kakao.com/o/g1QhacQh';
-
-    switch (reservation.shuttleRouteId) {
-      // 세븐틴 9/13 노선목록
-      case SHUTTLE_ROUTE_ID_13_대구:
-        return OPEN_CHAT_URL_13_대구;
-      case SHUTTLE_ROUTE_ID_13_부산:
-        return OPEN_CHAT_URL_13_부산;
-      case SHUTTLE_ROUTE_ID_13_대전:
-        return OPEN_CHAT_URL_13_대전;
-      case SHUTTLE_ROUTE_ID_13_천안아산:
-        return OPEN_CHAT_URL_13_천안아산;
-      case SHUTTLE_ROUTE_ID_13_청주:
-        return OPEN_CHAT_URL_13_청주;
-      // 세븐틴 9/14 노선목록
-      case SHUTTLE_ROUTE_ID_14_대구:
-        return OPEN_CHAT_URL_14_대구;
-      case SHUTTLE_ROUTE_ID_14_부산:
-        return OPEN_CHAT_URL_14_부산;
-      case SHUTTLE_ROUTE_ID_14_대전:
-        return OPEN_CHAT_URL_14_대전;
-      case SHUTTLE_ROUTE_ID_14_천안아산:
-        return OPEN_CHAT_URL_14_천안아산;
-      case SHUTTLE_ROUTE_ID_14_청주:
-        return OPEN_CHAT_URL_14_청주;
-
-      default:
-        return null;
-    }
-  }, [reservation.shuttleRouteId]);
+  const { isSeventeenEvent, temporaryNoticeRoomUrl } =
+    useTempSeventeen(reservation);
 
   const noticeRoomUrl = isSeventeenEvent
     ? temporaryNoticeRoomUrl

--- a/src/app/mypage/boarding-pass/hooks/useBoardingPassData.ts
+++ b/src/app/mypage/boarding-pass/hooks/useBoardingPassData.ts
@@ -1,8 +1,8 @@
 'use client';
 
+import useTempSeventeen from '@/hooks/useTempSeventeen';
 import { ReservationsViewEntity } from '@/types/reservation.type';
 import dayjs from 'dayjs';
-import { useMemo } from 'react';
 
 // 편도노선일 경우를 함께 고려하여 검증
 const useBoardingPassData = (reservation: ReservationsViewEntity) => {
@@ -90,58 +90,8 @@ const useBoardingPassData = (reservation: ReservationsViewEntity) => {
       dailyEvent.dailyEventId === reservation.shuttleRoute.dailyEventId,
   );
 
-  const isSeventeenEvent =
-    reservation.shuttleRoute.eventId === '603038379151464486';
-  const temporaryNoticeRoomUrl: string | null = useMemo(() => {
-    const SHUTTLE_ROUTE_ID_13_대구 = '613618546496246356';
-    const SHUTTLE_ROUTE_ID_13_부산 = '613620913623012086';
-    const SHUTTLE_ROUTE_ID_13_대전 = '611769613054644567';
-    const SHUTTLE_ROUTE_ID_13_천안아산 = '613615679391666718';
-    const SHUTTLE_ROUTE_ID_13_청주 = '611771163789496897';
-    const OPEN_CHAT_URL_13_대구 = 'https://open.kakao.com/o/gwew7bQh';
-    const OPEN_CHAT_URL_13_부산 = 'https://open.kakao.com/o/gp1J7bQh';
-    const OPEN_CHAT_URL_13_대전 = 'https://open.kakao.com/o/gaoW7bQh';
-    const OPEN_CHAT_URL_13_천안아산 = 'https://open.kakao.com/o/gOF77bQh';
-    const OPEN_CHAT_URL_13_청주 = 'https://open.kakao.com/o/grNn8bQh';
-    const SHUTTLE_ROUTE_ID_14_대구 = '613623549873099706';
-    const SHUTTLE_ROUTE_ID_14_부산 = '613622643945378707';
-    const SHUTTLE_ROUTE_ID_14_대전 = '611770340053357083';
-    const SHUTTLE_ROUTE_ID_14_천안아산 = '613624012286727144';
-    const SHUTTLE_ROUTE_ID_14_청주 = '611771616103240128';
-    const OPEN_CHAT_URL_14_대구 = 'https://open.kakao.com/o/gRTC8bQh';
-    const OPEN_CHAT_URL_14_부산 = 'https://open.kakao.com/o/gSJS8bQh';
-    const OPEN_CHAT_URL_14_대전 = 'https://open.kakao.com/o/gbVe9bQh';
-    const OPEN_CHAT_URL_14_천안아산 = 'https://open.kakao.com/o/gZau9bQh';
-    const OPEN_CHAT_URL_14_청주 = 'https://open.kakao.com/o/g1QhacQh';
-
-    switch (reservation.shuttleRouteId) {
-      // 세븐틴 9/13 노선목록
-      case SHUTTLE_ROUTE_ID_13_대구:
-        return OPEN_CHAT_URL_13_대구;
-      case SHUTTLE_ROUTE_ID_13_부산:
-        return OPEN_CHAT_URL_13_부산;
-      case SHUTTLE_ROUTE_ID_13_대전:
-        return OPEN_CHAT_URL_13_대전;
-      case SHUTTLE_ROUTE_ID_13_천안아산:
-        return OPEN_CHAT_URL_13_천안아산;
-      case SHUTTLE_ROUTE_ID_13_청주:
-        return OPEN_CHAT_URL_13_청주;
-      // 세븐틴 9/14 노선목록
-      case SHUTTLE_ROUTE_ID_14_대구:
-        return OPEN_CHAT_URL_14_대구;
-      case SHUTTLE_ROUTE_ID_14_부산:
-        return OPEN_CHAT_URL_14_부산;
-      case SHUTTLE_ROUTE_ID_14_대전:
-        return OPEN_CHAT_URL_14_대전;
-      case SHUTTLE_ROUTE_ID_14_천안아산:
-        return OPEN_CHAT_URL_14_천안아산;
-      case SHUTTLE_ROUTE_ID_14_청주:
-        return OPEN_CHAT_URL_14_청주;
-
-      default:
-        return null;
-    }
-  }, [reservation.shuttleRouteId]);
+  const { isSeventeenEvent, temporaryNoticeRoomUrl } =
+    useTempSeventeen(reservation);
   const noticeRoomUrl = isSeventeenEvent
     ? temporaryNoticeRoomUrl
     : dailyEvent?.metadata?.openChatUrl;

--- a/src/app/mypage/shuttle/components/reservations/reservation-card/components/ChatButton.tsx
+++ b/src/app/mypage/shuttle/components/reservations/reservation-card/components/ChatButton.tsx
@@ -3,6 +3,7 @@ import Button from '@/components/buttons/button/Button';
 import { ReservationsViewEntity } from '@/types/reservation.type';
 import { useRouter } from 'next/navigation';
 import { handleClickAndStopPropagation } from '@/utils/common.util';
+import useTempSeventeen from '@/hooks/useTempSeventeen';
 
 interface Props {
   reservation: ReservationsViewEntity;
@@ -23,11 +24,15 @@ const ChatButton = ({
 }: Props) => {
   const router = useRouter();
 
+  const { isSeventeenEvent, temporaryNoticeRoomUrl } =
+    useTempSeventeen(reservation);
   // NOTE: 일자별 노선의 metadata에 오픈채팅방 링크를 임시로 반영하기로 함. 앱 출시 후 삭제예정
-  const noticeRoomUrl = reservation.shuttleRoute.event.dailyEvents.find(
-    (dailyEvent) =>
-      dailyEvent.dailyEventId === reservation.shuttleRoute.dailyEventId,
-  )?.metadata?.openChatUrl;
+  const noticeRoomUrl = isSeventeenEvent
+    ? temporaryNoticeRoomUrl
+    : reservation.shuttleRoute.event.dailyEvents.find(
+        (dailyEvent) =>
+          dailyEvent.dailyEventId === reservation.shuttleRoute.dailyEventId,
+      )?.metadata?.openChatUrl;
 
   const openOpenChatLink = () => {
     if (noticeRoomUrl) {

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/Content.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/Content.tsx
@@ -20,7 +20,7 @@ import { checkIsHandyParty } from '@/utils/handyParty.util';
 import HandyPartyProgressSection from './sections/shuttle-progress-section/HandyPartyProgressSection';
 import Button from '@/components/buttons/button/Button';
 import { handleClickAndStopPropagation } from '@/utils/common.util';
-import { useMemo } from 'react';
+import useTempSeventeen from '@/hooks/useTempSeventeen';
 
 interface Props {
   reservation: ReservationsViewEntity;
@@ -61,58 +61,8 @@ const Content = ({ reservation, payment, shuttleBus }: Props) => {
 
   const isHandyParty = checkIsHandyParty(shuttleRoute);
 
-  const isSeventeenEvent =
-    reservation.shuttleRoute.eventId === '603038379151464486';
-  const temporaryNoticeRoomUrl: string | null = useMemo(() => {
-    const SHUTTLE_ROUTE_ID_13_대구 = '613618546496246356';
-    const SHUTTLE_ROUTE_ID_13_부산 = '613620913623012086';
-    const SHUTTLE_ROUTE_ID_13_대전 = '611769613054644567';
-    const SHUTTLE_ROUTE_ID_13_천안아산 = '613615679391666718';
-    const SHUTTLE_ROUTE_ID_13_청주 = '611771163789496897';
-    const OPEN_CHAT_URL_13_대구 = 'https://open.kakao.com/o/gwew7bQh';
-    const OPEN_CHAT_URL_13_부산 = 'https://open.kakao.com/o/gp1J7bQh';
-    const OPEN_CHAT_URL_13_대전 = 'https://open.kakao.com/o/gaoW7bQh';
-    const OPEN_CHAT_URL_13_천안아산 = 'https://open.kakao.com/o/gOF77bQh';
-    const OPEN_CHAT_URL_13_청주 = 'https://open.kakao.com/o/grNn8bQh';
-    const SHUTTLE_ROUTE_ID_14_대구 = '613623549873099706';
-    const SHUTTLE_ROUTE_ID_14_부산 = '613622643945378707';
-    const SHUTTLE_ROUTE_ID_14_대전 = '611770340053357083';
-    const SHUTTLE_ROUTE_ID_14_천안아산 = '613624012286727144';
-    const SHUTTLE_ROUTE_ID_14_청주 = '611771616103240128';
-    const OPEN_CHAT_URL_14_대구 = 'https://open.kakao.com/o/gRTC8bQh';
-    const OPEN_CHAT_URL_14_부산 = 'https://open.kakao.com/o/gSJS8bQh';
-    const OPEN_CHAT_URL_14_대전 = 'https://open.kakao.com/o/gbVe9bQh';
-    const OPEN_CHAT_URL_14_천안아산 = 'https://open.kakao.com/o/gZau9bQh';
-    const OPEN_CHAT_URL_14_청주 = 'https://open.kakao.com/o/g1QhacQh';
-
-    switch (reservation.shuttleRouteId) {
-      // 세븐틴 9/13 노선목록
-      case SHUTTLE_ROUTE_ID_13_대구:
-        return OPEN_CHAT_URL_13_대구;
-      case SHUTTLE_ROUTE_ID_13_부산:
-        return OPEN_CHAT_URL_13_부산;
-      case SHUTTLE_ROUTE_ID_13_대전:
-        return OPEN_CHAT_URL_13_대전;
-      case SHUTTLE_ROUTE_ID_13_천안아산:
-        return OPEN_CHAT_URL_13_천안아산;
-      case SHUTTLE_ROUTE_ID_13_청주:
-        return OPEN_CHAT_URL_13_청주;
-      // 세븐틴 9/14 노선목록
-      case SHUTTLE_ROUTE_ID_14_대구:
-        return OPEN_CHAT_URL_14_대구;
-      case SHUTTLE_ROUTE_ID_14_부산:
-        return OPEN_CHAT_URL_14_부산;
-      case SHUTTLE_ROUTE_ID_14_대전:
-        return OPEN_CHAT_URL_14_대전;
-      case SHUTTLE_ROUTE_ID_14_천안아산:
-        return OPEN_CHAT_URL_14_천안아산;
-      case SHUTTLE_ROUTE_ID_14_청주:
-        return OPEN_CHAT_URL_14_청주;
-
-      default:
-        return null;
-    }
-  }, [reservation.shuttleRouteId]);
+  const { isSeventeenEvent, temporaryNoticeRoomUrl } =
+    useTempSeventeen(reservation);
 
   // NOTE: 일자별 노선의 metadata에 오픈채팅방 링크를 임시로 반영하기로 함. 앱 출시 후 삭제예정
   const noticeRoomUrl = isSeventeenEvent

--- a/src/hooks/useTempSeventeen.ts
+++ b/src/hooks/useTempSeventeen.ts
@@ -1,0 +1,73 @@
+import { ReservationsViewEntity } from '@/types/reservation.type';
+import { useMemo } from 'react';
+
+const useTempSeventeen = (reservation: ReservationsViewEntity) => {
+  const isSeventeenEvent =
+    reservation.shuttleRoute.eventId === '603038379151464486';
+
+  const temporaryNoticeRoomUrl: string | null = useMemo(() => {
+    const SHUTTLE_ROUTE_ID_13_대구 = '613618546496246356';
+    const SHUTTLE_ROUTE_ID_13_부산 = '613620913623012086';
+    const SHUTTLE_ROUTE_ID_13_대전 = '611769613054644567';
+    const SHUTTLE_ROUTE_ID_13_명동합정 = '618712186428070633';
+    const SHUTTLE_ROUTE_ID_13_천안아산 = '613615679391666718';
+    const SHUTTLE_ROUTE_ID_13_청주 = '611771163789496897';
+    const OPEN_CHAT_URL_13_대구 = 'https://open.kakao.com/o/gwew7bQh';
+    const OPEN_CHAT_URL_13_부산 = 'https://open.kakao.com/o/gp1J7bQh';
+    const OPEN_CHAT_URL_13_대전 = 'https://open.kakao.com/o/gaoW7bQh';
+    const OPEN_CHAT_URL_13_명동합정 = 'https://open.kakao.com/o/g5wSkfQh';
+    const OPEN_CHAT_URL_13_천안아산 = 'https://open.kakao.com/o/gOF77bQh';
+    const OPEN_CHAT_URL_13_청주 = 'https://open.kakao.com/o/grNn8bQh';
+    const SHUTTLE_ROUTE_ID_14_대구 = '613623549873099706';
+    const SHUTTLE_ROUTE_ID_14_부산 = '613622643945378707';
+    const SHUTTLE_ROUTE_ID_14_대전 = '611770340053357083';
+    const SHUTTLE_ROUTE_ID_14_명동합정 = '618712575495904064';
+    const SHUTTLE_ROUTE_ID_14_천안아산 = '613624012286727144';
+    const SHUTTLE_ROUTE_ID_14_청주 = '611771616103240128';
+    const OPEN_CHAT_URL_14_대구 = 'https://open.kakao.com/o/gRTC8bQh';
+    const OPEN_CHAT_URL_14_부산 = 'https://open.kakao.com/o/gSJS8bQh';
+    const OPEN_CHAT_URL_14_대전 = 'https://open.kakao.com/o/gbVe9bQh';
+    const OPEN_CHAT_URL_14_명동합정 = 'https://open.kakao.com/o/g5rnlfQh';
+    const OPEN_CHAT_URL_14_천안아산 = 'https://open.kakao.com/o/gZau9bQh';
+    const OPEN_CHAT_URL_14_청주 = 'https://open.kakao.com/o/g1QhacQh';
+
+    switch (reservation.shuttleRouteId) {
+      // 세븐틴 9/13 노선목록
+      case SHUTTLE_ROUTE_ID_13_대구:
+        return OPEN_CHAT_URL_13_대구;
+      case SHUTTLE_ROUTE_ID_13_부산:
+        return OPEN_CHAT_URL_13_부산;
+      case SHUTTLE_ROUTE_ID_13_대전:
+        return OPEN_CHAT_URL_13_대전;
+      case SHUTTLE_ROUTE_ID_13_명동합정:
+        return OPEN_CHAT_URL_13_명동합정;
+      case SHUTTLE_ROUTE_ID_13_천안아산:
+        return OPEN_CHAT_URL_13_천안아산;
+      case SHUTTLE_ROUTE_ID_13_청주:
+        return OPEN_CHAT_URL_13_청주;
+      // 세븐틴 9/14 노선목록
+      case SHUTTLE_ROUTE_ID_14_대구:
+        return OPEN_CHAT_URL_14_대구;
+      case SHUTTLE_ROUTE_ID_14_부산:
+        return OPEN_CHAT_URL_14_부산;
+      case SHUTTLE_ROUTE_ID_14_대전:
+        return OPEN_CHAT_URL_14_대전;
+      case SHUTTLE_ROUTE_ID_14_명동합정:
+        return OPEN_CHAT_URL_14_명동합정;
+      case SHUTTLE_ROUTE_ID_14_천안아산:
+        return OPEN_CHAT_URL_14_천안아산;
+      case SHUTTLE_ROUTE_ID_14_청주:
+        return OPEN_CHAT_URL_14_청주;
+
+      default:
+        return null;
+    }
+  }, [reservation.shuttleRouteId]);
+
+  return {
+    isSeventeenEvent,
+    temporaryNoticeRoomUrl,
+  };
+};
+
+export default useTempSeventeen;


### PR DESCRIPTION
## 개요
외국인 노선인 명동합정 노선 옵챗 추가 및 reservation card 에도 임시 오픈챗 연결을 해두었습니다.
커스텀 훅으로 공통로직으로 처리해두었습니다

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).