### PR TITLE
feat: 예약상세 - 지도 및 로드뷰 미리보기에 핸디팟 케이스 대응, 후기 로딩 ui 여백 추가

### DIFF
--- a/src/app/mypage/reviews/components/WritableReviews.tsx
+++ b/src/app/mypage/reviews/components/WritableReviews.tsx
@@ -52,7 +52,10 @@ const WritableReviews = () => {
   );
 
   return (
-    <DeferredSuspense fallback={<Loading style="grow" />} isLoading={isLoading}>
+    <DeferredSuspense
+      fallback={<Loading style="grow" className="pt-64" />}
+      isLoading={isLoading}
+    >
       {reservationsWithNotWrittenReview &&
         (reservationsWithNotWrittenReview.length === 0 ? (
           <EmptyReview variant="writable-review" />

--- a/src/app/mypage/reviews/components/WrittenReviews.tsx
+++ b/src/app/mypage/reviews/components/WrittenReviews.tsx
@@ -50,7 +50,7 @@ const WrittenReviews = () => {
         setPeriodFilter={setPeriodFilter}
       />
       <DeferredSuspense
-        fallback={<Loading style="grow" />}
+        fallback={<Loading style="grow" className="pt-64" />}
         isLoading={isLoading}
       >
         {reservationsWithReview &&

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
@@ -36,12 +36,12 @@ const ShuttleInfoSection = ({
 }: Props) => {
   const destinationHub =
     tripType === 'TO_DESTINATION'
-      ? shuttleRoute.toDestinationShuttleRouteHubs
-          ?.sort((a, b) => a.sequence - b.sequence)
-          ?.at(-1)
-      : shuttleRoute.fromDestinationShuttleRouteHubs?.sort(
-          (a, b) => a.sequence - b.sequence,
-        )?.[0];
+      ? shuttleRoute.toDestinationShuttleRouteHubs?.find(
+          (hub) => hub.role === 'DESTINATION',
+        )
+      : shuttleRoute.fromDestinationShuttleRouteHubs?.find(
+          (hub) => hub.role === 'DESTINATION',
+        );
 
   return (
     <>

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
@@ -34,6 +34,15 @@ const ShuttleInfoSection = ({
   desiredHubLatitude,
   desiredHubLongitude,
 }: Props) => {
+  const destinationHub =
+    tripType === 'TO_DESTINATION'
+      ? shuttleRoute.toDestinationShuttleRouteHubs
+          ?.sort((a, b) => a.sequence - b.sequence)
+          ?.at(-1)
+      : shuttleRoute.fromDestinationShuttleRouteHubs?.sort(
+          (a, b) => a.sequence - b.sequence,
+        )?.[0];
+
   return (
     <>
       <section className="px-16">
@@ -44,11 +53,11 @@ const ShuttleInfoSection = ({
               <TripCard
                 tripType="TO_DESTINATION"
                 hub={toDestinationHub}
-                shuttleRoute={shuttleRoute}
+                destinationHub={destinationHub}
                 withRoundTrip={tripType === 'ROUND_TRIP'}
                 passengerCount={passengerCount}
                 isHandyParty={isHandyParty}
-                desiredHubAddress={desiredHubAddress ?? '[집앞하차]'}
+                desiredHubAddress={desiredHubAddress ?? '[집앞승차]'}
                 desiredHubLatitude={desiredHubLatitude}
                 desiredHubLongitude={desiredHubLongitude}
               />
@@ -58,7 +67,7 @@ const ShuttleInfoSection = ({
               <TripCard
                 tripType="FROM_DESTINATION"
                 hub={fromDestinationHub}
-                shuttleRoute={shuttleRoute}
+                destinationHub={destinationHub}
                 withRoundTrip={tripType === 'ROUND_TRIP'}
                 passengerCount={passengerCount}
                 isHandyParty={isHandyParty}
@@ -120,27 +129,15 @@ const ShuttleInfoSection = ({
           </>
         )}
       {(tripType === 'ROUND_TRIP' || tripType === 'FROM_DESTINATION') &&
-        fromDestinationHub && (
+        destinationHub && (
           <>
             <div className="h-8 w-full bg-basic-grey-50" />
             <section className="px-16">
               <h3 className="pb-16 text-16 font-600">귀가행 탑승 장소</h3>
               <MapContainer
-                placeName={
-                  isHandyParty && desiredHubAddress
-                    ? desiredHubAddress
-                    : fromDestinationHub.name
-                }
-                latitude={
-                  isHandyParty && desiredHubLongitude
-                    ? desiredHubLongitude
-                    : fromDestinationHub.latitude
-                }
-                longitude={
-                  isHandyParty && desiredHubLongitude
-                    ? desiredHubLongitude
-                    : fromDestinationHub.longitude
-                }
+                placeName={destinationHub?.name}
+                latitude={destinationHub?.latitude}
+                longitude={destinationHub?.longitude}
                 type="MAP"
               />
               <div className="pb-8" />

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
@@ -76,16 +76,39 @@ const ShuttleInfoSection = ({
             <div className="h-8 w-full bg-basic-grey-50" />
             <section className="px-16">
               <h3 className="pb-16 text-16 font-600">행사장행 탑승지 정보</h3>
+              {isHandyParty && (
+                <p className="mb-16 rounded-8 bg-basic-red-100 p-8 text-12 font-500 leading-[160%] text-basic-red-400">
+                  이면도로·주차장·주정차금지구역 등으로 운행이 어려울 경우, 탑승
+                  장소가 조정될 수 있습니다. 탑승 전 꼭 기사님의 연락을
+                  확인해주세요.
+                </p>
+              )}
               <MapContainer
-                placeName={toDestinationHub.name}
-                latitude={toDestinationHub.latitude}
+                placeName={
+                  isHandyParty && desiredHubAddress
+                    ? desiredHubAddress
+                    : toDestinationHub.name
+                }
+                latitude={
+                  isHandyParty && desiredHubLatitude
+                    ? desiredHubLatitude
+                    : toDestinationHub.latitude
+                }
                 longitude={toDestinationHub.longitude}
                 type="MAP"
               />
               <div className="pb-16" />
               <MapContainer
-                placeName={toDestinationHub.name}
-                latitude={toDestinationHub.latitude}
+                placeName={
+                  isHandyParty && desiredHubAddress
+                    ? desiredHubAddress
+                    : toDestinationHub.name
+                }
+                latitude={
+                  isHandyParty && desiredHubLatitude
+                    ? desiredHubLatitude
+                    : toDestinationHub.latitude
+                }
                 longitude={toDestinationHub.longitude}
                 type="LOAD_VIEW"
               />
@@ -103,9 +126,21 @@ const ShuttleInfoSection = ({
             <section className="px-16">
               <h3 className="pb-16 text-16 font-600">귀가행 탑승지 정보</h3>
               <MapContainer
-                placeName={fromDestinationHub.name}
-                latitude={fromDestinationHub.latitude}
-                longitude={fromDestinationHub.longitude}
+                placeName={
+                  isHandyParty && desiredHubAddress
+                    ? desiredHubAddress
+                    : fromDestinationHub.name
+                }
+                latitude={
+                  isHandyParty && desiredHubLongitude
+                    ? desiredHubLongitude
+                    : fromDestinationHub.latitude
+                }
+                longitude={
+                  isHandyParty && desiredHubLongitude
+                    ? desiredHubLongitude
+                    : fromDestinationHub.longitude
+                }
                 type="MAP"
               />
               <div className="pb-8" />

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
@@ -75,7 +75,7 @@ const ShuttleInfoSection = ({
           <>
             <div className="h-8 w-full bg-basic-grey-50" />
             <section className="px-16">
-              <h3 className="pb-16 text-16 font-600">행사장행 탑승지 정보</h3>
+              <h3 className="pb-16 text-16 font-600">행사장행 탑승 장소</h3>
               {isHandyParty && (
                 <p className="mb-16 rounded-8 bg-basic-red-100 p-8 text-12 font-500 leading-[160%] text-basic-red-400">
                   이면도로·주차장·주정차금지구역 등으로 운행이 어려울 경우, 탑승
@@ -124,7 +124,7 @@ const ShuttleInfoSection = ({
           <>
             <div className="h-8 w-full bg-basic-grey-50" />
             <section className="px-16">
-              <h3 className="pb-16 text-16 font-600">귀가행 탑승지 정보</h3>
+              <h3 className="pb-16 text-16 font-600">귀가행 탑승 장소</h3>
               <MapContainer
                 placeName={
                   isHandyParty && desiredHubAddress

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
@@ -83,10 +83,10 @@ const ShuttleInfoSection = ({
         toDestinationHub && (
           <>
             <div className="h-8 w-full bg-basic-grey-50" />
-            <section className="px-16">
-              <h3 className="pb-16 text-16 font-600">행사장행 탑승 장소</h3>
+            <section className="flex flex-col gap-16 px-16">
+              <h3 className="text-16 font-600">행사장행 탑승 장소</h3>
               {isHandyParty && (
-                <p className="mb-16 rounded-8 bg-basic-red-100 p-8 text-12 font-500 leading-[160%] text-basic-red-400">
+                <p className="rounded-8 bg-basic-red-100 p-8 text-12 font-500 leading-[160%] text-basic-red-400">
                   이면도로·주차장·주정차금지구역 등으로 운행이 어려울 경우, 탑승
                   장소가 조정될 수 있습니다. 탑승 전 꼭 기사님의 연락을
                   확인해주세요.
@@ -106,25 +106,25 @@ const ShuttleInfoSection = ({
                 longitude={toDestinationHub.longitude}
                 type="MAP"
               />
-              <div className="pb-16" />
-              <MapContainer
-                placeName={
-                  isHandyParty && desiredHubAddress
-                    ? desiredHubAddress
-                    : toDestinationHub.name
-                }
-                latitude={
-                  isHandyParty && desiredHubLatitude
-                    ? desiredHubLatitude
-                    : toDestinationHub.latitude
-                }
-                longitude={toDestinationHub.longitude}
-                type="LOAD_VIEW"
-              />
-              <div className="pb-8" />
-              <p className="text-14 font-500 leading-[160%] text-basic-grey-600">
-                카카오맵에서 제공되는 이미지로, 현재와 다를 수 있습니다.
-              </p>
+              <div>
+                <MapContainer
+                  placeName={
+                    isHandyParty && desiredHubAddress
+                      ? desiredHubAddress
+                      : toDestinationHub.name
+                  }
+                  latitude={
+                    isHandyParty && desiredHubLatitude
+                      ? desiredHubLatitude
+                      : toDestinationHub.latitude
+                  }
+                  longitude={toDestinationHub.longitude}
+                  type="LOAD_VIEW"
+                />
+                <p className="pt-8 text-14 font-500 leading-[160%] text-basic-grey-600">
+                  카카오맵에서 제공되는 이미지로, 현재와 다를 수 있습니다.
+                </p>
+              </div>
             </section>
           </>
         )}
@@ -132,24 +132,25 @@ const ShuttleInfoSection = ({
         destinationHub && (
           <>
             <div className="h-8 w-full bg-basic-grey-50" />
-            <section className="px-16">
-              <h3 className="pb-16 text-16 font-600">귀가행 탑승 장소</h3>
-              <MapContainer
-                placeName={destinationHub?.name}
-                latitude={destinationHub?.latitude}
-                longitude={destinationHub?.longitude}
-                type="MAP"
-              />
-              <div className="pb-8" />
-              <ul className="list-disc pl-20 text-14 font-500 leading-[160%] text-basic-grey-600">
-                <li>
-                  정확한 탑승 위치는 당일 공연 종료 직후 문자로 안내됩니다.
-                </li>
-                <li>
-                  귀가행 탑승 시간은 공연 종료 시간에 따라 지연되며, 변경된 탑승
-                  시간은 당일에 문자로 안내됩니다.
-                </li>
-              </ul>
+            <section className="flex flex-col gap-16 px-16">
+              <h3 className="text-16 font-600">귀가행 탑승 장소</h3>
+              <div>
+                <MapContainer
+                  placeName={destinationHub?.name}
+                  latitude={destinationHub?.latitude}
+                  longitude={destinationHub?.longitude}
+                  type="MAP"
+                />
+                <ul className="list-disc pl-20 pt-8 text-14 font-500 leading-[160%] text-basic-grey-600">
+                  <li>
+                    정확한 탑승 위치는 당일 공연 종료 직후 문자로 안내됩니다.
+                  </li>
+                  <li>
+                    귀가행 탑승 시간은 공연 종료 시간에 따라 지연되며, 변경된
+                    탑승 시간은 당일에 문자로 안내됩니다.
+                  </li>
+                </ul>
+              </div>
             </section>
           </>
         )}

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/components/HubItem.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/components/HubItem.tsx
@@ -1,4 +1,3 @@
-import Button from '@/components/buttons/button/Button';
 import { ShuttleRouteHubsInShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
 
 interface Props {
@@ -19,24 +18,7 @@ const HubItem = ({
   hideTime = false,
   isHandyParty = false,
   desiredHubAddress,
-  desiredHubLatitude,
-  desiredHubLongitude,
 }: Props) => {
-  const openKakaoMapWithLocation = () => {
-    if (isHandyParty) {
-      window.open(
-        `https://map.kakao.com/link/map/${desiredHubAddress},${desiredHubLatitude},${desiredHubLongitude}`,
-        '_blank',
-        'noopener,noreferrer',
-      );
-    } else {
-      window.open(
-        `https://map.kakao.com/link/map/${hub.name},${hub.latitude},${hub.longitude}`,
-        '_blank',
-        'noopener,noreferrer',
-      );
-    }
-  };
   return (
     <li className="flex h-36 w-full items-center gap-16">
       <div className="shrink-0">
@@ -51,15 +33,6 @@ const HubItem = ({
       <div className="text-16 font-600">
         {isHandyParty ? desiredHubAddress : hub.name}
       </div>
-      <Button
-        type="button"
-        variant="tertiary"
-        size="small"
-        onClick={openKakaoMapWithLocation}
-        className="ml-auto"
-      >
-        지도
-      </Button>
     </li>
   );
 };

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/components/TripCard.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/components/TripCard.tsx
@@ -1,6 +1,6 @@
 import { TRIP_STATUS_TO_STRING } from '@/constants/status';
 import { CustomError } from '@/services/custom-error';
-import { ShuttleRoutesViewEntity, TripType } from '@/types/shuttleRoute.type';
+import { TripType } from '@/types/shuttleRoute.type';
 import { ShuttleRouteHubsInShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
 import { dateString } from '@/utils/dateString.util';
 import DotIcon from '../icons/dot-primary.svg';
@@ -10,7 +10,7 @@ import HubItem from './HubItem';
 interface Props {
   tripType: Exclude<TripType, 'ROUND_TRIP'>;
   hub: ShuttleRouteHubsInShuttleRoutesViewEntity;
-  shuttleRoute: ShuttleRoutesViewEntity;
+  destinationHub: ShuttleRouteHubsInShuttleRoutesViewEntity | undefined;
   withRoundTrip: boolean;
   passengerCount: number;
   isHandyParty: boolean;
@@ -22,7 +22,7 @@ interface Props {
 const TripCard = ({
   tripType,
   hub,
-  shuttleRoute,
+  destinationHub,
   withRoundTrip,
   passengerCount,
   isHandyParty,
@@ -42,14 +42,6 @@ const TripCard = ({
     showTime: true,
     showWeekday: false,
   });
-  const destinationHub =
-    tripType === 'TO_DESTINATION'
-      ? shuttleRoute.toDestinationShuttleRouteHubs
-          ?.sort((a, b) => a.sequence - b.sequence)
-          ?.at(-1)
-      : shuttleRoute.fromDestinationShuttleRouteHubs?.sort(
-          (a, b) => a.sequence - b.sequence,
-        )?.[0];
 
   if (!destinationHub) {
     throw new CustomError(404, '도착지를 찾을 수 없습니다.');

--- a/src/components/loading/Loading.tsx
+++ b/src/components/loading/Loading.tsx
@@ -1,13 +1,18 @@
 import { BeatLoader } from 'react-spinners';
+import { customTwMerge } from 'tailwind.config';
 
 interface Props {
   style?: 'screen' | 'grow';
+  className?: string;
 }
 
-const Loading = ({ style = 'screen' }: Props) => {
+const Loading = ({ style = 'screen', className }: Props) => {
   return (
     <div
-      className={`flex ${style === 'screen' ? 'h-[100dvh]' : 'grow'} items-center justify-center`}
+      className={customTwMerge(
+        `flex ${style === 'screen' ? 'h-[100dvh]' : 'grow'} items-center justify-center`,
+        className,
+      )}
     >
       <BeatLoader color="#9edbcc" />
     </div>


### PR DESCRIPTION
## 개요
- 핸디팟을 예매한 경우 희망 주소지로 지도 및 로드뷰를 보여주도록 합니다.
- 핸디팟 행사장행일 경우에는 추가 안내 문구를 보여줍니다.
- 귀가행 탑승 장소가 기존에 도착지 정보를 보여주던 것에서 출발지 정보를 보여주도록 변경하였습니다
- 마이페이지 - 후기 페이지에서 로딩 ui 의 여백을 추가하였습니다.

 

|셔틀버스|핸디팟 행사장행|핸디팟 귀가행|
|-|-|-|
|<img width="352" height="1290" alt="Screenshot 2025-09-18 at 5 26 48 PM" src="https://github.com/user-attachments/assets/0ad92fae-9f1d-45a5-a5ed-103a4539d5d4" />|<img width="367" height="1291" alt="Screenshot 2025-09-18 at 5 27 02 PM" src="https://github.com/user-attachments/assets/2623eba9-e259-472b-adc8-f804944c1fa0" />|<img width="356" height="1293" alt="Screenshot 2025-09-18 at 5 27 22 PM" src="https://github.com/user-attachments/assets/58ffda4a-fcea-4b8c-b484-445c63d98710" />|

<img width="362" height="292" alt="Screenshot 2025-09-18 at 5 48 42 PM" src="https://github.com/user-attachments/assets/ce7c3413-bc67-4640-aa1c-6816b71eb0e1" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).