### PR TITLE
feat: 예약취소, 셔틀 종료 상태에서는 예약 상세 페이지 모달 방지

### DIFF
--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/FirstVisitModal.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/FirstVisitModal.tsx
@@ -10,9 +10,10 @@ import Button from '@/components/buttons/button/Button';
 
 interface Props {
   reservationId: string;
+  isHidden: boolean;
 }
 
-const FirstVisitModal = ({ reservationId }: Props) => {
+const FirstVisitModal = ({ reservationId, isHidden }: Props) => {
   const [isFirstVisitModalOpen, setIsFirstVisitModalOpen] = useState(false);
 
   const closeModal = () => {
@@ -28,7 +29,7 @@ const FirstVisitModal = ({ reservationId }: Props) => {
   };
 
   useEffect(() => {
-    handleFirstVisitModalCheck();
+    if (!isHidden) handleFirstVisitModalCheck();
   }, []);
 
   return (

--- a/src/app/mypage/shuttle/reservation/[reservationId]/page.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/page.tsx
@@ -28,12 +28,19 @@ const Page = ({ params }: Props) => {
     reservationDetail?.reservation.shuttleRoute.shuttleRouteId ?? '',
     reservationDetail?.reservation.shuttleBusId ?? '',
   );
-
   const isLoading = !!(
     isLoadingReservation ||
     (reservationDetail &&
       reservationDetail.reservation.shuttleBusId &&
       isLoadingShuttleBus)
+  );
+  const isShuttleRouteEnded = Boolean(
+    reservationDetail?.reservation.shuttleRoute.status === 'ENDED' ||
+      reservationDetail?.reservation.shuttleRoute.status === 'CANCELLED' ||
+      reservationDetail?.reservation.shuttleRoute.status === 'INACTIVE',
+  );
+  const isReservationCanceled = Boolean(
+    reservationDetail?.reservation.reservationStatus === 'CANCEL',
   );
 
   useEffect(() => {
@@ -59,7 +66,12 @@ const Page = ({ params }: Props) => {
         )}
       </DeferredSuspense>
       <KakaoMapScript libraries={['services']} />
-      <FirstVisitModal reservationId={reservationId} />
+      {reservationDetail && (
+        <FirstVisitModal
+          reservationId={reservationId}
+          isHidden={isShuttleRouteEnded || isReservationCanceled}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## 개요
예약취소, 셔틀 종료 상태에서는 예약 상세 페이지 모달을 띄워주지 않습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).