### PR TITLE
fix: 로드뷰 줌, 세로각도(tilt) 반영 및 예약취소/셔틀종료 예약내역에서 모달이 뜨던 이슈 해결

### DIFF
--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/ShuttleInfoSection.tsx
@@ -135,6 +135,7 @@ const ShuttleInfoSection = ({
                       : toDestinationHub.longitude
                   }
                   roadviewPan={toDestinationHub.roadViewPan}
+                  roadviewTilt={toDestinationHub.roadViewTilt}
                 />
                 <div className="pt-8 text-14 font-500 leading-[160%] text-basic-grey-600">
                   이미지를 돌려가며 주변을 확인해보세요.
@@ -223,11 +224,13 @@ const RoadviewContainer = ({
   latitude,
   longitude,
   roadviewPan,
+  roadviewTilt,
 }: {
   placeName: string;
   latitude: number;
   longitude: number;
   roadviewPan: number | null;
+  roadviewTilt: number | null;
 }) => {
   return (
     <section>
@@ -242,6 +245,7 @@ const RoadviewContainer = ({
           latitude={latitude}
           longitude={longitude}
           roadviewPan={roadviewPan}
+          roadviewTilt={roadviewTilt}
         />
       </section>
     </section>

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/components/Roadview.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/components/Roadview.tsx
@@ -9,14 +9,19 @@ interface Props {
   latitude: number;
   longitude: number;
   roadviewPan: number | null;
+  roadviewTilt: number | null;
 }
 
-const Roadview = ({ placeName, latitude, longitude, roadviewPan }: Props) => {
+const Roadview = ({
+  placeName,
+  latitude,
+  longitude,
+  roadviewPan,
+  roadviewTilt,
+}: Props) => {
   const mapRef = useRef<HTMLDivElement>(null);
   const isInitialized = useRef(false);
   const [isAvailable, setIsAvailable] = useState(true);
-  const latitudeFixed8 = Number(latitude.toFixed(8));
-  const longitudeFixed8 = Number(longitude.toFixed(8));
 
   const initializeRoadview = () => {
     try {
@@ -24,10 +29,7 @@ const Roadview = ({ placeName, latitude, longitude, roadviewPan }: Props) => {
 
       const roadview = new window.kakao.maps.Roadview(mapRef.current);
       const roadviewClient = new window.kakao.maps.RoadviewClient();
-      const position = new window.kakao.maps.LatLng(
-        latitudeFixed8,
-        longitudeFixed8,
-      );
+      const position = new window.kakao.maps.LatLng(latitude, longitude);
 
       roadviewClient.getNearestPanoId(position, 50, (panoId) => {
         if (!panoId) {
@@ -40,8 +42,8 @@ const Roadview = ({ placeName, latitude, longitude, roadviewPan }: Props) => {
         window.kakao.maps.event.addListener(roadview, 'init', () => {
           roadview.setViewpoint({
             pan: roadviewPan ?? 0,
-            tilt: 28,
-            zoom: 1,
+            tilt: roadviewTilt ?? 0,
+            zoom: -3,
           });
 
           // 커스텀 오버레이 생성
@@ -71,6 +73,8 @@ const Roadview = ({ placeName, latitude, longitude, roadviewPan }: Props) => {
           placeName,
           latitude,
           longitude,
+          roadviewPan,
+          roadviewTilt,
           timestamp: dayjs().toISOString(),
         },
       });

--- a/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/components/Roadview.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/components/sections/shuttle-info-section/components/Roadview.tsx
@@ -15,6 +15,8 @@ const Roadview = ({ placeName, latitude, longitude, roadviewPan }: Props) => {
   const mapRef = useRef<HTMLDivElement>(null);
   const isInitialized = useRef(false);
   const [isAvailable, setIsAvailable] = useState(true);
+  const latitudeFixed8 = Number(latitude.toFixed(8));
+  const longitudeFixed8 = Number(longitude.toFixed(8));
 
   const initializeRoadview = () => {
     try {
@@ -22,7 +24,10 @@ const Roadview = ({ placeName, latitude, longitude, roadviewPan }: Props) => {
 
       const roadview = new window.kakao.maps.Roadview(mapRef.current);
       const roadviewClient = new window.kakao.maps.RoadviewClient();
-      const position = new window.kakao.maps.LatLng(latitude, longitude);
+      const position = new window.kakao.maps.LatLng(
+        latitudeFixed8,
+        longitudeFixed8,
+      );
 
       roadviewClient.getNearestPanoId(position, 50, (panoId) => {
         if (!panoId) {

--- a/src/app/mypage/shuttle/reservation/[reservationId]/page.tsx
+++ b/src/app/mypage/shuttle/reservation/[reservationId]/page.tsx
@@ -59,21 +59,23 @@ const Page = ({ params }: Props) => {
           event &&
           dailyEvent &&
           isKakaoScriptLoaded && (
-            <Content
-              reservation={reservation}
-              payment={payment}
-              event={event}
-              dailyEvent={dailyEvent}
-            />
+            <>
+              <Content
+                reservation={reservation}
+                payment={payment}
+                event={event}
+                dailyEvent={dailyEvent}
+              />
+              <FirstVisitModal
+                reservationId={reservationId}
+                isHidden={isShuttleRouteEnded || isReservationCanceled}
+              />
+            </>
           )}
       </DeferredSuspense>
       <KakaoMapScript
         libraries={['services']}
         onReady={() => setIsKakaoScriptLoaded(true)}
-      />
-      <FirstVisitModal
-        reservationId={reservationId}
-        isHidden={isShuttleRouteEnded || isReservationCanceled}
       />
     </>
   );


### PR DESCRIPTION
## 개요
로드뷰 세로각도(tilt) 반영 및 예약취소/셔틀종료 예약내역에서 모달이 뜨던 이슈 해결되었습니다

- 로드뷰 초기 렌더링시 zoom 을 최대한 멀리 땡겨서 유저들이 탑승장소를 좀 더 잘 인지할 수 있게 변경합니다.
- tilt 값은 고정값에서 어드민에서 설정한 값이 반영되게 변경하였습니다. 초기엔 살짝 하단을 바라보게 설정해두면 대부분의 장소에서도 적절한 시점이라고 판단되어 설정해두었는데요, 모든 정류장에 적절한 값이라고 보기 어려워 어드민에서 추가 설정 및 반영하게 변경해두었습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).